### PR TITLE
Add report component

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_MAPBOX_TOKEN=pk.eyJ1IjoicXVha2VzYWZlIiwiYSI6ImNtMzNlOXplbzAyeDQybm9scWdzaGtqMXUifQ.MyDa7RK6pe-tcPvkFmHbng

--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_MAPBOX_TOKEN=pk.eyJ1IjoicXVha2VzYWZlIiwiYSI6ImNtMzNlOXplbzAyeDQybm9scWdzaGtqMXUifQ.MyDa7RK6pe-tcPvkFmHbng

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ node_modules
 # Sensitive config
 .env.development.local
 .env
+.env.local

--- a/app/components/__mocks__/address-data.js
+++ b/app/components/__mocks__/address-data.js
@@ -1,6 +1,0 @@
-export const AddressData = {
-  softStory: "Non-compliant",
-  seismic: "No data",
-  tsunami: "Compliant",
-  address: "1000 Great Highway",
-};

--- a/app/components/__mocks__/address-data.ts
+++ b/app/components/__mocks__/address-data.ts
@@ -1,0 +1,13 @@
+export interface AddressDataType {
+  softStory: string;
+  seismic: string;
+  tsunami: string;
+  address: string;
+}
+
+export const AddressData: AddressDataType = {
+  softStory: "Non-compliant",
+  seismic: "No data",
+  tsunami: "Compliant",
+  address: "1000 Great Highway",
+};

--- a/app/components/__mocks__/hazards.js
+++ b/app/components/__mocks__/hazards.js
@@ -1,5 +1,6 @@
 export const Hazards = [
   {
+    id: 1,
     title: "Soft story",
     description:
       "Soft story buildings have less structural integrity in an earthquake",
@@ -7,6 +8,7 @@ export const Hazards = [
     color: "#171923",
   },
   {
+    id: 2,
     title: "Seismic",
     description:
       "This region is known to experience more focused seismic activity",
@@ -14,6 +16,7 @@ export const Hazards = [
     color: "#F6AD55",
   },
   {
+    id: 3,
     title: "Tsunami",
     description:
       "These coastal areas can be at risk of flooding in the event of a tsunami",

--- a/app/components/__mocks__/hazards.js
+++ b/app/components/__mocks__/hazards.js
@@ -1,6 +1,7 @@
 export const Hazards = [
   {
     id: 1,
+    name: "softStory",
     title: "Soft story",
     description:
       "Soft story buildings have less structural integrity in an earthquake",
@@ -9,6 +10,7 @@ export const Hazards = [
   },
   {
     id: 2,
+    name: "seismic",
     title: "Seismic",
     description:
       "This region is known to experience more focused seismic activity",
@@ -17,6 +19,7 @@ export const Hazards = [
   },
   {
     id: 3,
+    name: "tsunami",
     title: "Tsunami",
     description:
       "These coastal areas can be at risk of flooding in the event of a tsunami",

--- a/app/components/__tests__/card-hazard.test.tsx
+++ b/app/components/__tests__/card-hazard.test.tsx
@@ -12,7 +12,9 @@ jest.mock("../pill.tsx", () => () => (
 describe("CardHazard Component", () => {
   beforeEach(() => {
     Hazards[0] = {
+      id: 4,
       title: "Earthquake",
+      name: "seismic",
       description: "Potential hazard in the area.",
       color: "#FF0000",
       update: "2 days ago",
@@ -20,12 +22,12 @@ describe("CardHazard Component", () => {
   });
 
   it("renders without crashing", () => {
-    render(<CardHazard />);
+    render(<CardHazard hazard={Hazards[0]} />);
     expect(screen.getByText("Earthquake")).toBeInTheDocument();
   });
 
   it("displays the hazard title and description", () => {
-    render(<CardHazard />);
+    render(<CardHazard hazard={Hazards[0]} />);
     expect(screen.getByText("Earthquake")).toBeInTheDocument();
     expect(
       screen.getByText("Potential hazard in the area.")
@@ -33,12 +35,12 @@ describe("CardHazard Component", () => {
   });
 
   it("displays the hazard's updated time", () => {
-    render(<CardHazard />);
+    render(<CardHazard hazard={Hazards[0]} />);
     expect(screen.getByText("Updated 2 days ago")).toBeInTheDocument();
   });
 
   it("displays the hazard's color in the SVG circle", () => {
-    render(<CardHazard />);
+    render(<CardHazard hazard={Hazards[0]} />);
     const svgCircle = screen.getByRole("img", { hidden: true });
     expect(svgCircle).toHaveAttribute("fill", "#FF0000");
   });

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -11,6 +11,7 @@ import Pill from "./pill";
 interface CardHazardProps {
   hazard: {
     id: number;
+    name: string;
     title: string;
     description: string;
     update: string;
@@ -18,7 +19,7 @@ interface CardHazardProps {
   };
 }
 
-const CardHazard: React.FC<CardHazardProps> = ({ hazard, addressData }) => {
+const CardHazard: React.FC<CardHazardProps> = ({ hazard }) => {
   const { title, description, update, color } = hazard;
   return (
     <Card maxW={332}>
@@ -31,7 +32,7 @@ const CardHazard: React.FC<CardHazardProps> = ({ hazard, addressData }) => {
       >
         <HStack justifyContent="space-between">
           <Text textStyle="textBig">{title}</Text>
-          <Pill />
+          <Pill name={hazard.name} />
         </HStack>
       </CardHeader>
       <CardBody

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   HStack,
 } from "@chakra-ui/react";
-import { Hazards } from "./__mocks__/hazards";
 import Pill from "./pill";
 
 interface CardHazardProps {
@@ -19,7 +18,7 @@ interface CardHazardProps {
   };
 }
 
-const CardHazard: React.FC<CardHazardProps> = ({ hazard }) => {
+const CardHazard: React.FC<CardHazardProps> = ({ hazard, addressData }) => {
   const { title, description, update, color } = hazard;
   return (
     <Card maxW={332}>

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -9,9 +9,18 @@ import {
 import { Hazards } from "./__mocks__/hazards";
 import Pill from "./pill";
 
-const CardHazard = () => {
-  const hazard = Hazards[0];
+interface CardHazardProps {
+  hazard: {
+    id: number;
+    title: string;
+    description: string;
+    update: string;
+    color: string;
+  };
+}
 
+const CardHazard: React.FC<CardHazardProps> = ({ hazard }) => {
+  const { title, description, update, color } = hazard;
   return (
     <Card maxW={332}>
       <CardHeader
@@ -22,7 +31,7 @@ const CardHazard = () => {
         }}
       >
         <HStack justifyContent="space-between">
-          <Text textStyle="textBig">{hazard.title}</Text>
+          <Text textStyle="textBig">{title}</Text>
           <Pill />
         </HStack>
       </CardHeader>
@@ -33,7 +42,7 @@ const CardHazard = () => {
           xl: "14px 22px 0px 22px",
         }}
       >
-        <Text textStyle="textMedium">{hazard.description}</Text>
+        <Text textStyle="textMedium">{description}</Text>
       </CardBody>
       <CardFooter
         p={{
@@ -48,12 +57,12 @@ const CardHazard = () => {
               cx="9.5"
               cy="9"
               r="8.5"
-              fill={hazard.color}
+              fill={color}
               stroke="white"
               role="img"
             />
           </svg>
-          <Text textStyle="textSmall">{"Updated " + hazard.update}</Text>
+          <Text textStyle="textSmall">{"Updated " + update}</Text>
         </HStack>
       </CardFooter>
     </Card>

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -19,8 +19,9 @@ interface CardHazardProps {
   };
 }
 
-const CardHazard: React.FC<CardHazardProps> = ({ hazard }) => {
-  const { title, description, update, color } = hazard;
+const CardHazard: React.FC<CardHazardProps> = ({
+  hazard: { title, name, description, update, color },
+}) => {
   return (
     <Card>
       <CardHeader
@@ -32,7 +33,7 @@ const CardHazard: React.FC<CardHazardProps> = ({ hazard }) => {
       >
         <HStack justifyContent="space-between">
           <Text textStyle="textBig">{title}</Text>
-          <Pill name={hazard.name} />
+          <Pill name={name} />
         </HStack>
       </CardHeader>
       <CardBody

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -22,7 +22,7 @@ interface CardHazardProps {
 const CardHazard: React.FC<CardHazardProps> = ({ hazard }) => {
   const { title, description, update, color } = hazard;
   return (
-    <Card maxW={332}>
+    <Card>
       <CardHeader
         p={{
           base: "10px 23px 0px 23px",

--- a/app/components/pill.tsx
+++ b/app/components/pill.tsx
@@ -1,7 +1,11 @@
 import { Box, Text } from "@chakra-ui/react";
-import { AddressData } from "./__mocks__/address-data";
+import { AddressData, AddressDataType } from "./__mocks__/address-data";
 
-const Pill = () => {
+interface PillProps {
+  name: string;
+}
+
+const Pill: React.FC<PillProps> = ({ name }) => {
   const getBgColor = (status: string) => {
     switch (status) {
       case "No data":
@@ -15,15 +19,17 @@ const Pill = () => {
     }
   };
 
+  const status = AddressData[name as keyof AddressDataType] || "No data";
+
   return (
     <Box>
       <Text
-        bgColor={getBgColor(AddressData.softStory)}
+        bgColor={getBgColor(status)}
         color="white"
         p="2px 12px 2px 12px"
         borderRadius="25"
       >
-        {AddressData.softStory}
+        {status}
       </Text>
     </Box>
   );

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -8,7 +8,9 @@ const Report = () => {
     <Box>
       <HStack justifyContent="space-between">
         {AddressData.address && (
-          <Text textStyle="headerMedium">{AddressData.address}</Text>
+          <Text textStyle="headerMedium" mb="16px">
+            {AddressData.address}
+          </Text>
         )}
         <HStack>
           <Text textStyle="textMedium" color="blue">

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -1,0 +1,57 @@
+import { Box, HStack, IconButton, Text } from "@chakra-ui/react";
+import { MdOutlineIosShare } from "react-icons/md";
+import { AddressData } from "./__mocks__/address-data";
+import CardHazard from "./card-hazard";
+import { Hazards } from "./__mocks__/hazards";
+
+const Report = () => {
+  return (
+    <Box>
+      <HStack justifyContent="space-between">
+        {AddressData.address && (
+          <Text textStyle="headerMedium">{AddressData.address}</Text>
+        )}
+        <HStack>
+          <Text textStyle="textMedium" color="blue">
+            Share report
+          </Text>
+          <IconButton aria-label="Share report" variant="ghost">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M4 11C4.55228 11 5 11.4477 5 12V20C5 20.2652 5.10536 20.5196 5.29289 20.7071C5.48043 20.8946 5.73478 21 6 21H18C18.2652 21 18.5196 20.8946 18.7071 20.7071C18.8946 20.5196 19 20.2652 19 20V12C19 11.4477 19.4477 11 20 11C20.5523 11 21 11.4477 21 12V20C21 20.7957 20.6839 21.5587 20.1213 22.1213C19.5587 22.6839 18.7957 23 18 23H6C5.20435 23 4.44129 22.6839 3.87868 22.1213C3.31607 21.5587 3 20.7956 3 20V12C3 11.4477 3.44772 11 4 11Z"
+                fill="#2C5282"
+              />
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M11.2929 1.29289C11.6834 0.902369 12.3166 0.902369 12.7071 1.29289L16.7071 5.29289C17.0976 5.68342 17.0976 6.31658 16.7071 6.70711C16.3166 7.09763 15.6834 7.09763 15.2929 6.70711L12 3.41421L8.70711 6.70711C8.31658 7.09763 7.68342 7.09763 7.29289 6.70711C6.90237 6.31658 6.90237 5.68342 7.29289 5.29289L11.2929 1.29289Z"
+                fill="#2C5282"
+              />
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M12 1C12.5523 1 13 1.44772 13 2V15C13 15.5523 12.5523 16 12 16C11.4477 16 11 15.5523 11 15V2C11 1.44772 11.4477 1 12 1Z"
+                fill="#2C5282"
+              />
+            </svg>
+          </IconButton>
+        </HStack>
+      </HStack>
+      <HStack justifyContent="space-between">
+        {Hazards.map((hazard) => {
+          return <CardHazard key={hazard.id} hazard={hazard} />;
+        })}
+      </HStack>
+    </Box>
+  );
+};
+
+export default Report;

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -6,11 +6,15 @@ import { Hazards } from "./__mocks__/hazards";
 const Report = () => {
   return (
     <Box>
-      <HStack justifyContent="space-between">
+      <HStack
+        justifyContent="space-between"
+        alignItems={{ base: "flex-start", md: "center" }}
+        flexDirection={{ base: "column", md: "row" }}
+        mb="16px"
+        gap="0"
+      >
         {AddressData.address && (
-          <Text textStyle="headerMedium" mb="16px">
-            {AddressData.address}
-          </Text>
+          <Text textStyle="headerMedium">{AddressData.address}</Text>
         )}
         <HStack>
           <Text textStyle="textMedium" color="blue">
@@ -25,20 +29,20 @@ const Report = () => {
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
+                fillRule="evenodd"
+                clipRule="evenodd"
                 d="M4 11C4.55228 11 5 11.4477 5 12V20C5 20.2652 5.10536 20.5196 5.29289 20.7071C5.48043 20.8946 5.73478 21 6 21H18C18.2652 21 18.5196 20.8946 18.7071 20.7071C18.8946 20.5196 19 20.2652 19 20V12C19 11.4477 19.4477 11 20 11C20.5523 11 21 11.4477 21 12V20C21 20.7957 20.6839 21.5587 20.1213 22.1213C19.5587 22.6839 18.7957 23 18 23H6C5.20435 23 4.44129 22.6839 3.87868 22.1213C3.31607 21.5587 3 20.7956 3 20V12C3 11.4477 3.44772 11 4 11Z"
                 fill="#2C5282"
               />
               <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
+                fillRule="evenodd"
+                clipRule="evenodd"
                 d="M11.2929 1.29289C11.6834 0.902369 12.3166 0.902369 12.7071 1.29289L16.7071 5.29289C17.0976 5.68342 17.0976 6.31658 16.7071 6.70711C16.3166 7.09763 15.6834 7.09763 15.2929 6.70711L12 3.41421L8.70711 6.70711C8.31658 7.09763 7.68342 7.09763 7.29289 6.70711C6.90237 6.31658 6.90237 5.68342 7.29289 5.29289L11.2929 1.29289Z"
                 fill="#2C5282"
               />
               <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
+                fillRule="evenodd"
+                clipRule="evenodd"
                 d="M12 1C12.5523 1 13 1.44772 13 2V15C13 15.5523 12.5523 16 12 16C11.4477 16 11 15.5523 11 15V2C11 1.44772 11.4477 1 12 1Z"
                 fill="#2C5282"
               />
@@ -46,7 +50,11 @@ const Report = () => {
           </IconButton>
         </HStack>
       </HStack>
-      <HStack justifyContent="space-between">
+      <HStack
+        justifyContent="space-between"
+        alignItems="stretch"
+        flexDirection={{ base: "column", md: "row" }}
+      >
         {Hazards.map((hazard) => {
           return <CardHazard key={hazard.id} hazard={hazard} />;
         })}

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -1,7 +1,6 @@
 import { Box, HStack, IconButton, Text } from "@chakra-ui/react";
-import { MdOutlineIosShare } from "react-icons/md";
-import { AddressData } from "./__mocks__/address-data";
 import CardHazard from "./card-hazard";
+import { AddressData } from "./__mocks__/address-data";
 import { Hazards } from "./__mocks__/hazards";
 
 const Report = () => {

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -2,6 +2,7 @@ import { Box, HStack, IconButton, Text } from "@chakra-ui/react";
 import CardHazard from "./card-hazard";
 import { AddressData } from "./__mocks__/address-data";
 import { Hazards } from "./__mocks__/hazards";
+import Map from "./map";
 
 const Report = () => {
   return (
@@ -54,6 +55,7 @@ const Report = () => {
         justifyContent="space-between"
         alignItems="stretch"
         flexDirection={{ base: "column", md: "row" }}
+        mb="16px"
       >
         {Hazards.map((hazard) => {
           return <CardHazard key={hazard.id} hazard={hazard} />;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,9 +25,21 @@ const Home = () => {
       <Box
         w={{ base: "base", xl: "xl" }}
         p={{
-          base: "23px 24px 27px 24px",
-          md: "37px 27px 28px 26px",
-          xl: "50px 128px 40px 127px",
+          base: "23px 24px 16px 24px",
+          md: "37px 27px 16px 26px",
+          xl: "50px 128px 16px 127px",
+        }}
+        m="auto"
+      >
+        <Report />
+      </Box>
+      <Box
+        w={{ base: "base", md: "741px", xl: "xl" }}
+        h={{ base: "323px", md: "411px", xl: "462px" }}
+        p={{
+          base: "0px 24px 27px 24px",
+          md: "0px 27px 28px 26px",
+          xl: "0px 128px 40px 127px",
         }}
         m="auto"
       >
@@ -40,9 +52,6 @@ const Home = () => {
           overflow="hidden"
         >
           <Map />
-          <Box>
-            <Report />
-          </Box>
         </Box>
       </Box>
       <Box bgColor="blue">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import SearchBar from "./components/search-bar";
 import Heading from "./components/heading";
 import Map from "./components/map";
 import "./globals.css";
+import Report from "./components/report";
 
 const Home = () => {
   return (
@@ -22,8 +23,7 @@ const Home = () => {
         </Box>
       </Box>
       <Box
-        w={{ base: "base", md: "741px", xl: "xl" }}
-        h={{ base: "323px", md: "411px", xl: "462px" }}
+        w={{ base: "base", xl: "xl" }}
         p={{
           base: "23px 24px 27px 24px",
           md: "37px 27px 28px 26px",
@@ -40,6 +40,8 @@ const Home = () => {
           overflow="hidden"
         >
           <Map />
+        <Box>
+          <Report />
         </Box>
       </Box>
       <Box bgColor="blue">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,8 +40,9 @@ const Home = () => {
           overflow="hidden"
         >
           <Map />
-        <Box>
-          <Report />
+          <Box>
+            <Report />
+          </Box>
         </Box>
       </Box>
       <Box bgColor="blue">


### PR DESCRIPTION
# Description

Add a "Report" component to display hazard information according to the current design solution. The component includes hazard cards and address details with placeholder for future share functionality. Adjusted for responsive layouts and integrated mock data, with all unit tests passing.

#82 

## Type of changes
- [ ] Bugfix
- [ ] Chore
- [x] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

https://github.com/user-attachments/assets/c9984f65-fb40-40bf-823d-540732f039f8

