### PR TITLE
Fixed typo

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,7 +38,7 @@ services:
     env_file:
       - .env
     volumes:
-      - db-data:/var/lib/postgr esql/data
+      - db-data:/var/lib/postgresql/data
       - ./backend/database:/docker-entrypoint-initdb.d # Mount the SQL scripts directory
     ports:
       - 5432:5432


### PR DESCRIPTION
# Description

Fixed a typo in compose.yaml

#115

## Type of changes
- [x] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test
Check compose.yaml to see that `postgresql` is one word.
