### PR TITLE
Create APIs for address risk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ node_modules
 .env.development.local
 .env
 .env.local
+
+# IDEs
+.vscode/

--- a/backend/api/routers/liquefaction_api.py
+++ b/backend/api/routers/liquefaction_api.py
@@ -45,7 +45,9 @@ async def get_liquefaction_zones(db: Session = Depends(get_db)):
 
 
 @router.get("/is-in-liquefaction-zone", response_model=bool)
-async def is_in_liquefaction_zone(lat: float, lon: float, db: Session = Depends(get_db)):
+async def is_in_liquefaction_zone(
+    lat: float, lon: float, db: Session = Depends(get_db)
+):
     """
     Check if a point is in a liquefaction zone.
 
@@ -59,6 +61,7 @@ async def is_in_liquefaction_zone(lat: float, lon: float, db: Session = Depends(
     """
     query = db.query(LiquefactionZone).filter(
         LiquefactionZone.geometry.ST_Contains(
-            geo_func.ST_SetSRID(geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326))
+            geo_func.ST_SetSRID(geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326)
+        )
     )
     return db.query(query.exists()).scalar()

--- a/backend/api/routers/soft_story_api.py
+++ b/backend/api/routers/soft_story_api.py
@@ -46,16 +46,16 @@ async def get_soft_stories(db: Session = Depends(get_db)):
 async def is_soft_story(lat: float, lon: float, db: Session = Depends(get_db)):
     """
     Check if a point is a soft story property.
-    
+
     Args:
         lat (float): Latitude of the point.
         lon (float): Longitude of the point.
         db (Session): The database session dependency.
-    
+
     Returns:
         bool: True if the point is a soft story property, False otherwise.
     """
     query = db.query(SoftStoryProperty).filter(
-        SoftStoryProperty.point == geo_func.ST_GeomFromText(f"POINT({lon} {lat})",4326)
+        SoftStoryProperty.point == geo_func.ST_GeomFromText(f"POINT({lon} {lat})", 4326)
     )
     return db.query(query.exists()).scalar()

--- a/backend/api/routers/soft_story_api.py
+++ b/backend/api/routers/soft_story_api.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, HTTPException, Depends
 from ..tags import Tags
 from sqlalchemy.orm import Session
 from backend.database.session import get_db
+from geoalchemy2 import functions as geo_func
 from backend.api.schemas.soft_story_schemas import (
     SoftStoryFeature,
     SoftStoryFeatureCollection,
@@ -39,3 +40,22 @@ async def get_soft_stories(db: Session = Depends(get_db)):
 
     features = [SoftStoryFeature.from_sqlalchemy_model(story) for story in soft_stories]
     return SoftStoryFeatureCollection(type="FeatureCollection", features=features)
+
+
+@router.get("/is-soft-story", response_model=bool)
+async def is_soft_story(lat: float, lon: float, db: Session = Depends(get_db)):
+    """
+    Check if a point is a soft story property.
+    
+    Args:
+        lat (float): Latitude of the point.
+        lon (float): Longitude of the point.
+        db (Session): The database session dependency.
+    
+    Returns:
+        bool: True if the point is a soft story property, False otherwise.
+    """
+    query = db.query(SoftStoryProperty).filter(
+        SoftStoryProperty.point == geo_func.ST_GeomFromText(f"POINT({lon} {lat})",4326)
+    )
+    return db.query(query.exists()).scalar()

--- a/backend/api/routers/tsunami_api.py
+++ b/backend/api/routers/tsunami_api.py
@@ -56,6 +56,7 @@ async def is_in_tsunami_zone(lat: float, lon: float, db: Session = Depends(get_d
     """
     query = db.query(TsunamiZone).filter(
         TsunamiZone.geometry.ST_Contains(
-            geo_func.ST_SetSRID(geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326))
+            geo_func.ST_SetSRID(geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326)
+        )
     )
     return db.query(query.exists()).scalar()

--- a/backend/api/routers/tsunami_api.py
+++ b/backend/api/routers/tsunami_api.py
@@ -3,6 +3,7 @@
 from fastapi import Depends, HTTPException, APIRouter
 from ..tags import Tags
 from sqlalchemy.orm import Session
+from geoalchemy2 import functions as geo_func
 from backend.database.session import get_db
 from backend.api.schemas.tsunami_schemas import TsunamiFeature, TsunamiFeatureCollection
 from backend.api.models.tsunami import TsunamiZone
@@ -38,3 +39,23 @@ async def get_tsunami_zones(db: Session = Depends(get_db)):
         raise HTTPException(status_code=404, detail="No tsunami zones found")
     features = [TsunamiFeature.from_sqlalchemy_model(zone) for zone in tsunami_zones]
     return TsunamiFeatureCollection(type="FeatureCollection", features=features)
+
+
+@router.get("/is-in-tsunami-zone", response_model=bool)
+async def is_in_tsunami_zone(lat: float, lon: float, db: Session = Depends(get_db)):
+    """
+    Check if a point is in a tsunami zone.
+
+    Args:
+        lat (float): Latitude of the point.
+        lon (float): Longitude of the point.
+        db (Session): The database session dependency.
+
+    Returns:
+        bool: True if the point is in a tsunami zone, False otherwise.
+    """
+    query = db.query(TsunamiZone).filter(
+        TsunamiZone.geometry.ST_Contains(
+            geo_func.ST_SetSRID(geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326))
+    )
+    return db.query(query.exists()).scalar()

--- a/backend/api/tests/test_soft_story.py
+++ b/backend/api/tests/test_soft_story.py
@@ -41,6 +41,7 @@ def test_get_soft_story(client):
     # Temporary guaranteed failure until test is written
     assert False
 
+
 def test_is_soft_story(client):
     lat, lon = [-122.446575165, 37.766034349]
     response = client.get(f"/api/soft-story/is-soft-story?lat={lat}&lon={lon}")
@@ -49,6 +50,8 @@ def test_is_soft_story(client):
 
     # These should not be soft stories
     wrong_lat, wrong_lon = [0.0, 0.0]
-    response = client.get(f"/api/soft-story/is-soft-story?lat={wrong_lat}&lon={wrong_lon}")
+    response = client.get(
+        f"/api/soft-story/is-soft-story?lat={wrong_lat}&lon={wrong_lon}"
+    )
     assert response.status_code == 200
     assert not response.json()  # False

--- a/backend/api/tests/test_soft_story.py
+++ b/backend/api/tests/test_soft_story.py
@@ -7,7 +7,6 @@ from fastapi.testclient import TestClient
 
 # Will the .. be stable?
 from ..main import app
-from ..schemas.geo import Polygon
 
 
 @pytest.fixture
@@ -41,3 +40,15 @@ def test_get_soft_story(client):
     assert response.status_code == 200
     # Temporary guaranteed failure until test is written
     assert False
+
+def test_is_soft_story(client):
+    lat, lon = [-122.446575165, 37.766034349]
+    response = client.get(f"/api/soft-story/is-soft-story?lat={lat}&lon={lon}")
+    assert response.status_code == 200
+    assert response.json()  # True
+
+    # These should not be soft stories
+    wrong_lat, wrong_lon = [0.0, 0.0]
+    response = client.get(f"/api/soft-story/is-soft-story?lat={wrong_lat}&lon={wrong_lon}")
+    assert response.status_code == 200
+    assert not response.json()  # False

--- a/backend/api/tests/test_tsunami.py
+++ b/backend/api/tests/test_tsunami.py
@@ -47,8 +47,14 @@ def test_get_tsunami_polygon(client):
     assert False
 
 
-def test_get_tsunami_risk(client):
-    response = client.get("/api/tsunami-risk/addresss")
+def test_is_in_tsunami_zone(client):
+    lat, lon = [37.759039, -122.509515]
+    response = client.get(f"/api/tsunami/is-in-tsunami-zone?lat={lat}&lon={lon}")
     assert response.status_code == 200
-    # Temporary guaranteed failure until test is written
-    assert False
+    assert response.json()  # True
+
+    # These should not be in our tsunami zone
+    wrong_lat, wrong_lon = [0.0, 0.0]
+    response = client.get(f"/api/tsunami/is-in-tsunami-zone?lat={wrong_lat}&lon={wrong_lon}")
+    assert response.status_code == 200
+    assert not response.json()  # False

--- a/backend/api/tests/test_tsunami.py
+++ b/backend/api/tests/test_tsunami.py
@@ -55,6 +55,8 @@ def test_is_in_tsunami_zone(client):
 
     # These should not be in our tsunami zone
     wrong_lat, wrong_lon = [0.0, 0.0]
-    response = client.get(f"/api/tsunami/is-in-tsunami-zone?lat={wrong_lat}&lon={wrong_lon}")
+    response = client.get(
+        f"/api/tsunami/is-in-tsunami-zone?lat={wrong_lat}&lon={wrong_lon}"
+    )
     assert response.status_code == 200
     assert not response.json()  # False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -34,6 +34,7 @@ pandas==2.2.3
 pathspec==0.12.1
 platformdirs==4.3.6
 pluggy==1.5.0
+pre_commit==4.0.1
 psycopg2-binary==2.9.9
 pydantic==2.9.0
 pydantic-settings==2.5.2


### PR DESCRIPTION
# Description

Implementing issue #128.

Three APIs with related tests:

- [x] API that, given an address, tells whether it is a soft story
- [x] API that, given an address, tells whether it is in a liquefaction zone
- [x] API that, given an address, tells whether it is in a zone at risk of tsunami

Translating the address obtained through MapBox autocomplete into a geometrical Point could be handled by the frontend (so we keep all MapBox-related stuff in the frontend), so it is currently out of scope.

---

**Also added pre_commit to requirements-dev.txt.**

## Type of changes
- [ ] Bugfix
- [ ] Chore
- [x] New Feature

## Testing
- [x] I added automated tests
- [ ] I think tests are unnecessary

## How to test

- Run app

### Soft-story
- Go to http://localhost:8000/soft-stories/is-soft-story?lat=-122.446575165&lon=37.766034349 and see that the response is `true`. This is a coordinate in our soft-story table.
- Go to http://localhost:8000/soft-stories/is-soft-story?lat=0&lon=0 and see that the response is `false`. This is Null Island, which is not in our table.

### Liquefaction
- Go to http://localhost:8000/liquefaction-zones/is-in-liquefaction-zone?lat=37.779759&lon=-122.407436 and see that the response is `true`. This is a point at 6th and Howard in a liquefaction zone.
- Go to http://localhost:8000/liquefaction-zones/is-in-liquefaction-zone?lat=0&lon=0 and see that the response is `false`. This is Null Island. Maybe it is in a liquefaction zone, but it's certainly out of our jurisdiction.

### Tsunami
- Go to http://localhost:8000/tsunami/is-in-tsunami-zone?lat=37.759039&lon=-122.509515 and see that the response is `true`. This is a point in the Outer Sunset in our table.
- Go to http://localhost:8000/tsunami/is-in-tsunami-zone?lat=0&lon=0 and see that the response is `false`. This is Null Island. Maybe it is at Tsunami risk but it's certainly out of our jurisdiction.