### PR TITLE
Default to local DB when running ETL locally

### DIFF
--- a/.github/workflows/env_vars.yml
+++ b/.github/workflows/env_vars.yml
@@ -24,7 +24,7 @@ jobs:
         envkey_DATABASE_URL_SQLALCHEMY: ${{ secrets.DATABASE_URL_SQLALCHEMY }}
         envkey_DATABASE_URL_SQLALCHEMY_TEST: ${{ secrets.DATABASE_URL_SQLALCHEMY_TEST }}
         envkey_LOCALHOST_DATABASE_URL_SQLALCHEMY: ${{ secrets.LOCALHOST_DATABASE_URL_SQLALCHEMY }}
-        envkey_ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
+        envkey_ENVIRONMENT: local
         envkey_SECRET_KEY: ${{ secrets.SECRET_KEY }}
 
         envkey_NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}

--- a/backend/api/config.py
+++ b/backend/api/config.py
@@ -20,11 +20,11 @@ class Settings(BaseSettings):
     database_url_sqlalchemy: str
     database_url_sqlalchemy_test: str
     localhost_database_url_sqlalchemy: str
-    environment: str
     secret_key: str
     next_public_api_url: str
     next_public_mapbox_token: str
     node_env: str
+    environment: str = "local"
 
     class Config:
         env_file = ".env"

--- a/backend/database/session.py
+++ b/backend/database/session.py
@@ -2,8 +2,19 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from backend.api.config import settings
 
+
+def _get_database_url() -> str:
+    match settings.environment:
+        case "local":
+            return settings.database_url_sqlalchemy
+        case "ci" | "prod":
+            return settings.neon_url
+        case _:
+            raise ValueError(f"Unknown environment: {settings.environment}")
+
+
 # Set up the database engine using settings
-engine = create_engine(settings.neon_url, echo=True)
+engine = create_engine(_get_database_url(), echo=True)
 
 # Create a session factory
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/backend/etl/soft_story_properties_data_handler.py
+++ b/backend/etl/soft_story_properties_data_handler.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.declarative import DeclarativeMeta
 from dotenv import load_dotenv
 import os
 from pathlib import Path
-from etl.mapbox_geojson_manager import MapboxConfig, MapboxGeojsonManager
+from backend.etl.mapbox_geojson_manager import MapboxConfig, MapboxGeojsonManager
 from backend.api.models.base import ModelType
 
 

--- a/backend/etl/soft_story_properties_data_handler.py
+++ b/backend/etl/soft_story_properties_data_handler.py
@@ -6,7 +6,6 @@ from sqlalchemy.ext.declarative import DeclarativeMeta
 from dotenv import load_dotenv
 import os
 from pathlib import Path
-from typing import Dict, Tuple
 from etl.mapbox_geojson_manager import MapboxConfig, MapboxGeojsonManager
 from backend.api.models.base import ModelType
 


### PR DESCRIPTION
# Description

This PR allows us to default to writing to the local DB when running the ETL process locally. 

Addresses #182.

It requires a GitHub secret change: ENVIRONMENT should be set to `ci` or `prod`. When generating the .env file, the ENVIRONMENT variable will be set to "local". It is currently in plain text.

Security-wise, this approach should be okay because:

1. We are not exposing a token, key, or host name, just an environment variable that is meaningless without the actual tokens and host names.
2. By manually changing the variable to "ci", an unauthorized user would only be able to create a session with the dummy NEON_URL variable in the .env.example, which still wouldn't allow them to write to production.

On the other hand, it is an easy change for an authorized user who needs to write to production bypassing GitHub action.

## Type of changes
- [x] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

Run ETL locally, see that it writes to the local DB and not the Neon DB.

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)