### PR TITLE
Stop installing Python dependencies in frontend docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ USER appuser
 EXPOSE 3000
 
 # Start the Next.js application in development mode
-CMD ["npm", "run", "dev"]   
+CMD ["npm", "run", "next-dev"]   


### PR DESCRIPTION
# Description

Setting up for the first time, I noticed the frontend container indirectly tries to run pip and a backend api script:
[./Dockerfile](https://github.com/sfbrigade/datasci-earthquake/blob/master/Dockerfile#L28-L29) `CMD ["npm", "run", "dev"]`
calls [./package.json](https://github.com/sfbrigade/datasci-earthquake/blob/master/package.json#L8) `"dev": "concurrently \"npm run next-dev\" \"npm run fastapi-dev\"",`
which calls `"fastapi-dev": "pip3 install -r requirements.txt && fastapi dev backend/api/main.py",`

Is this intentional? It seems unnecessary. (In fact, it fails on my machine. As-is, I cannot run the frontend using Docker.)

Suggestion: Stop installing Python dependencies in the frontend docker container. Let the backend container handle that. This small change should reduce spinup time and container size.

_This seems straightforward but I am brand new to this project. Do let me know if I am missing something._

## Type of changes
- [x] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test
The frontend container still runs locally without errors.

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean - There is only one commit.