### PR TITLE
Feature/connect search

### DIFF
--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -30,7 +30,7 @@ const ComponentsTestLib = () => {
       <VStack spacing={4} align="start">
         <HStack w="100%">
           <Box w="400px">
-            <SearchBar />
+            <SearchBar coordinates={[0, 0]} onSearchChange={() => {}} />
           </Box>
         </HStack>
         <Divider mb={2} />

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -1,0 +1,68 @@
+import { Box, Flex } from "@chakra-ui/react";
+import SearchBar from "./search-bar";
+import Heading, { HeadingProps } from "./heading";
+import Map from "./map";
+import Report from "./report";
+import Information from "./information";
+
+const addressLookupCoordinates = {
+  geometry: {
+    type: "Point",
+    coordinates: [-122.408020683, 37.801698301],
+  },
+};
+const coords = addressLookupCoordinates.geometry.coordinates ?? [];
+
+interface AddressMapperProps {
+  coords: number[];
+  headingData: HeadingProps;
+  softStoryData: {};
+  tsunamiData: {};
+  liquefactionData: {};
+}
+
+const AddressMapper: React.FC<AddressMapperProps> = ({
+  coords,
+  headingData,
+  softStoryData,
+  tsunamiData,
+  liquefactionData,
+}) => {
+  return (
+    <Flex direction="column">
+      <Box bgColor="blue">
+        <Box
+          w={{ base: "base", xl: "xl" }}
+          p={{
+            base: "45px 23px 50px 23px",
+            md: "52px 260px 56px 26px",
+            xl: "53px 470px 46px 127px",
+          }}
+          m="auto"
+        >
+          <Heading headingData={headingData} />
+          <SearchBar />
+        </Box>
+      </Box>
+      <Box w="base" h={{ base: "1400px", md: "1000px" }} m="auto">
+        <Box
+          h="100%"
+          border="1px solid"
+          borderColor="grey.400"
+          overflow="hidden"
+          position="relative"
+        >
+          <Box zIndex={10} top={0} position="absolute">
+            <Report />
+          </Box>
+          <Map coordinates={coords} />
+          <Box position="absolute" bottom={0}>
+            <Information />
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  );
+};
+
+export default AddressMapper;

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import { Box, Flex } from "@chakra-ui/react";
 import SearchBar from "./search-bar";
 import Heading, { HeadingProps } from "./heading";
@@ -11,23 +14,28 @@ const addressLookupCoordinates = {
     coordinates: [-122.408020683, 37.801698301],
   },
 };
-const coords = addressLookupCoordinates.geometry.coordinates ?? [];
+const defaultCoords = addressLookupCoordinates.geometry.coordinates ?? [];
 
 interface AddressMapperProps {
-  coords: number[];
   headingData: HeadingProps;
   softStoryData: {};
   tsunamiData: {};
   liquefactionData: {};
 }
 
+// TODO: pass data down to Map component
 const AddressMapper: React.FC<AddressMapperProps> = ({
-  coords,
   headingData,
   softStoryData,
   tsunamiData,
   liquefactionData,
 }) => {
+  const [coordinates, setCoordinates] = useState(defaultCoords);
+
+  const updateMap = (coords: number[]) => {
+    setCoordinates(coords);
+  };
+
   return (
     <Flex direction="column">
       <Box bgColor="blue">
@@ -41,7 +49,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
           m="auto"
         >
           <Heading headingData={headingData} />
-          <SearchBar />
+          <SearchBar coordinates={coordinates} onSearchChange={updateMap} />
         </Box>
       </Box>
       <Box w="base" h={{ base: "1400px", md: "1000px" }} m="auto">
@@ -55,7 +63,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
           <Box zIndex={10} top={0} position="absolute">
             <Report />
           </Box>
-          <Map coordinates={coords} />
+          <Map coordinates={coordinates} />
           <Box position="absolute" bottom={0}>
             <Information />
           </Box>

--- a/app/components/heading.tsx
+++ b/app/components/heading.tsx
@@ -1,6 +1,6 @@
 import { Highlight, Text } from "@chakra-ui/react";
 
-interface HeadingProps {
+export interface HeadingProps {
   text: string;
   highlight: string;
   style?: {

--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useRef, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import mapboxgl, { LngLat } from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { FeatureCollection, Geometry } from "geojson";
@@ -22,12 +23,11 @@ interface MapProps {
   coordinates: number[];
 }
 
-const Map: React.FC<MapProps> = (
-  { coordinates } = { coordinates: defaultCoords }
-) => {
-  const addressLngLat = new LngLat(coordinates[0], coordinates[1]);
+const Map: React.FC<MapProps> = ({ coordinates = defaultCoords }: MapProps) => {
+  const debug = useSearchParams().get("debug");
   const mapContainerRef = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<mapboxgl.Map | null>(null);
+  const mapRef = useRef<mapboxgl.Map>();
+  const markerRef = useRef<mapboxgl.Marker>();
 
   useEffect(() => {
     const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
@@ -40,9 +40,8 @@ const Map: React.FC<MapProps> = (
 
     mapboxgl.accessToken = mapboxToken;
 
-    if (mapRef.current) {
-      return;
-    } else {
+    if (!mapRef.current) {
+      // initial pass: render map
       mapRef.current = new mapboxgl.Map({
         container: mapContainerRef.current!,
         style: "mapbox://styles/mapbox/standard",
@@ -74,10 +73,12 @@ const Map: React.FC<MapProps> = (
       const nav = new mapboxgl.NavigationControl({ showCompass: false });
       map.addControl(nav, "right");
 
+      // wait for map to load before drawing marker
       map.on("load", () => {
         // Draw address marker
         const el = document.createElement("div");
 
+        const addressLngLat = new LngLat(coordinates[0], coordinates[1]);
         const addressMarker = new mapboxgl.Marker({
           anchor: "bottom",
           element: el,
@@ -85,6 +86,8 @@ const Map: React.FC<MapProps> = (
         })
           .setLngLat(addressLngLat)
           .addTo(map);
+
+        markerRef.current = addressMarker;
 
         // Add sources
         map.addSource("seismic", {
@@ -139,15 +142,35 @@ const Map: React.FC<MapProps> = (
           },
         });
       });
-
-      return () => {
-        if (mapRef.current) mapRef.current.remove();
-      };
+    } else {
+      // subsequent passes: update map
+      const map = mapRef.current;
+      const addressLngLat = new LngLat(coordinates[0], coordinates[1]);
+      map.panTo(addressLngLat);
+      markerRef.current?.setLngLat(addressLngLat);
+      return;
     }
-  }, []);
+  }, [coordinates]);
 
   return (
-    <div ref={mapContainerRef} style={{ width: "100%", height: "100%" }} />
+    <>
+      <div ref={mapContainerRef} style={{ width: "100%", height: "100%" }} />
+      {debug === "true" && (
+        <span
+          style={{
+            backgroundColor: "pink",
+            position: "absolute",
+            top: 0,
+            right: 0,
+            zIndex: 99,
+            fontSize: 24,
+            padding: "4px",
+          }}
+        >
+          {`${coordinates[0]}, ${coordinates[1]}`}
+        </span>
+      )}
+    </>
   );
 };
 

--- a/app/components/search-bar.jsx
+++ b/app/components/search-bar.jsx
@@ -1,19 +1,27 @@
 "use client";
 
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import {
+  HStack,
   Input,
   InputGroup,
   InputLeftElement,
   InputRightElement,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
 } from "@chakra-ui/react";
 import { IoSearchSharp } from "react-icons/io5";
 import { RxCross2 } from "react-icons/rx";
 import DynamicAddressAutofill from "./address-autofill";
 
-const SearchBar = () => {
+const SearchBar = ({ coordinates, onSearchChange }) => {
   const [address, setAddress] = useState("");
   const [fullAddress, setFullAddress] = useState(null);
+  const debug = useSearchParams().get("debug");
 
   const handleClearClick = () => {
     console.log(address);
@@ -24,10 +32,50 @@ const SearchBar = () => {
   const handleRetrieve = (event) => {
     const addressData = event.features[0];
     setFullAddress(addressData);
+    // TODO: move to proper event handler and replace with coordinates from API
+    onSearchChange([coordinates[0] + 0.025, coordinates[1] + 0.025]);
   };
 
   return (
     <form>
+      {debug === "true" && (
+        <HStack>
+          <NumberInput
+            bg="white"
+            size="xs"
+            width="auto"
+            defaultValue={coordinates[0]}
+            precision={9}
+            step={0.005}
+            onChange={(valueString) =>
+              onSearchChange([parseFloat(valueString), coordinates[1]])
+            }
+          >
+            <NumberInputField />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+          <NumberInput
+            bg="white"
+            size="xs"
+            width="auto"
+            defaultValue={coordinates[1]}
+            precision={9}
+            step={0.005}
+            onChange={(valueString) =>
+              onSearchChange([coordinates[0], parseFloat(valueString)])
+            }
+          >
+            <NumberInputField />
+            <NumberInputStepper>
+              <NumberIncrementStepper />
+              <NumberDecrementStepper />
+            </NumberInputStepper>
+          </NumberInput>
+        </HStack>
+      )}
       <DynamicAddressAutofill
         accessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
         onRetrieve={handleRetrieve}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,6 @@
-import { Box, Flex, Text } from "@chakra-ui/react";
-import SearchBar from "./components/search-bar";
-import Heading from "./components/heading";
-import Map from "./components/map";
 import "./globals.css";
-import Report from "./components/report";
-import Information from "./components/information";
+
+import AddressMapper from "./components/address-mapper";
 import { Headings } from "./data/data";
 import {
   fetchSoftStories,
@@ -28,39 +24,13 @@ const Home = async () => {
   const liquefactionData = await fetchLiquefaction();
 
   return (
-    <Flex direction="column">
-      <Box bgColor="blue">
-        <Box
-          w={{ base: "base", xl: "xl" }}
-          p={{
-            base: "45px 23px 50px 23px",
-            md: "52px 260px 56px 26px",
-            xl: "53px 470px 46px 127px",
-          }}
-          m="auto"
-        >
-          <Heading headingData={headingData} />
-          <SearchBar />
-        </Box>
-      </Box>
-      <Box w="base" h={{ base: "1400px", md: "1000px" }} m="auto">
-        <Box
-          h="100%"
-          border="1px solid"
-          borderColor="grey.400"
-          overflow="hidden"
-          position="relative"
-        >
-          <Box zIndex={10} top={0} position="absolute">
-            <Report />
-          </Box>
-          <Map coordinates={coords} />
-          <Box position="absolute" bottom={0}>
-            <Information />
-          </Box>
-        </Box>
-      </Box>
-    </Flex>
+    <AddressMapper
+      coords={coords}
+      headingData={headingData}
+      softStoryData={softStoryData}
+      tsunamiData={tsunamiData}
+      liquefactionData={liquefactionData}
+    />
   );
 };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,14 +8,6 @@ import {
   fetchLiquefaction,
 } from "./api/services";
 
-const addressLookupCoordinates = {
-  geometry: {
-    type: "Point",
-    coordinates: [-122.408020683, 37.801698301],
-  },
-};
-const coords = addressLookupCoordinates.geometry.coordinates ?? [];
-
 const Home = async () => {
   const headingData = Headings.home;
 
@@ -25,7 +17,6 @@ const Home = async () => {
 
   return (
     <AddressMapper
-      coords={coords}
       headingData={headingData}
       softStoryData={softStoryData}
       tsunamiData={tsunamiData}


### PR DESCRIPTION
# Description

This PR shares coordinates between the search bar and the map component. There is also some refactoring.

Behind the scenes, it also splits the root `page.tsx`'s JSX out into a new client component so that the page can remain server-rendered. The server-side fetched data is passed down to eventually be consumed by the map (future PR). The search bar now triggers an update of the coordinates (via callback) after an autocomplete and select is initiated. This is intended to use the coordinates that come back from our API (PR in progress).

Addresses but may not close #91. 

## Type of changes
- [ ] Bugfix
- [x] Chore
- [x] New Feature

## Testing
- [ ] I added automated tests
- [ ] I think tests are unnecessary

## How to test

- Search for and select address as a user
- Note that the map pans and the marker moves accordingly (currently a fixed amount just for demo purposes, meant to be replaced by the new address coordinates from the API)

Turn on debugging by appending `?debug=true` to the URL (e.g., http://localhost?debug=true or for the preview, https://datasci-earthquake-git-feature-conne-8ab614-nickvisuts-projects.vercel.app/?debug=true)

This will bring up a debugging UI that lets you experiment with how different coordinates update the map.

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)