### PR TITLE
[ETL] Re-enable tsunami data handler execution in backend startup script

### DIFF
--- a/backend/etl/startup.sh
+++ b/backend/etl/startup.sh
@@ -4,7 +4,7 @@ set -e
 python backend/database/init_db.py
 python backend/etl/liquefaction_data_handler.py
 python backend/etl/soft_story_properties_data_handler.py
-#python backend/etl/tsunami_data_handler.py
+python backend/etl/tsunami_data_handler.py
 
 # Start FastAPI
 uvicorn api.index:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
# Description

Script logs during backend startup:
```
backend-1           | 2025-02-09 02:56:07,142 - TsunamiDataHandler - INFO - Initialized handler for TsunamiZone with URL: https://services2.arcgis.com/zr3KAIbsRSUyARHG/ArcGIS/rest/services/CA_Tsunami_Hazard_Area/FeatureServer/0/query, page size: 1000
backend-1           | 2025-02-09 02:56:07,142 - TsunamiDataHandler - INFO - Starting data fetch for TsunamiZone
backend-1           | 2025-02-09 02:56:07,444 - TsunamiDataHandler - INFO - TsunamiZone: Received fewer records (2) than page size (1000). Assuming final page and stopping fetch. Request time: 0.30s
backend-1           | 2025-02-09 02:56:07,445 - TsunamiDataHandler - INFO - TsunamiZone: Successfully fetched 2 total features.
```

Ensured the db gets updated with the data
```
qsdatabase=# select count(*) from tsunami_zones;
 count
-------
     2
(1 row)
```

https://github.com/sfbrigade/datasci-earthquake/issues/200

## Type of changes
- [x] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think automated tests are unnecessary
- [x] I performed manual testing

## How to test

1. Run the system using `docker-compose up -d`.
2. Review the backend logs to ensure `tsunami_data_handler` is successfully executed as part of the startup script.
3. Review the `tsunami_zones` table to ensure entries are being generated.

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)