### PR TITLE
Add `last_updated` datetime to the `is-*` apis.

### DIFF
--- a/backend/api/routers/liquefaction_api.py
+++ b/backend/api/routers/liquefaction_api.py
@@ -8,8 +8,15 @@ from backend.database.session import get_db
 from ..schemas.liquefaction_schemas import (
     LiquefactionFeature,
     LiquefactionFeatureCollection,
+    IsInLiquefactionZoneView,
 )
 from backend.api.models.liquefaction_zones import LiquefactionZone
+import logging
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/api/liquefaction-zones",
@@ -44,7 +51,7 @@ async def get_liquefaction_zones(db: Session = Depends(get_db)):
     return LiquefactionFeatureCollection(type="FeatureCollection", features=features)
 
 
-@router.get("/is-in-liquefaction-zone", response_model=bool)
+@router.get("/is-in-liquefaction-zone", response_model=IsInLiquefactionZoneView)
 async def is_in_liquefaction_zone(
     lon: float, lat: float, db: Session = Depends(get_db)
 ):
@@ -57,11 +64,42 @@ async def is_in_liquefaction_zone(
         db (Session): The database session dependency.
 
     Returns:
-        bool: True if the point is in a liquefaction zone, False otherwise.
+        IsInLiquefactionZoneView containing:
+            - exists: True if point is in a liquefaction zone
+            - last_updated: Timestamp of last update if exists, None otherwise
     """
-    query = db.query(LiquefactionZone).filter(
-        LiquefactionZone.geometry.ST_Contains(
-            geo_func.ST_SetSRID(geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326)
+    logger.info(f"Checking liquefaction zone for coordinates: lon={lon}, lat={lat}")
+
+    try:
+        query = db.query(LiquefactionZone).filter(
+            LiquefactionZone.geometry.ST_Contains(
+                geo_func.ST_SetSRID(
+                    geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326
+                )
+            )
         )
-    )
-    return db.query(query.exists()).scalar()
+
+        exists = db.query(query.exists()).scalar()
+
+        zone = query.first() if exists else None
+        last_updated = zone.update_timestamp if zone else None
+
+        logger.info(
+            f"Liquefaction zone check result for coordinates: lon={lon}, lat={lat} - "
+            f"exists: {exists}, "
+            f"last_updated: {last_updated}"
+        )
+
+        return IsInLiquefactionZoneView(exists=exists, last_updated=last_updated)
+
+    except Exception as e:
+        logger.error(
+            f"Error checking liquefaction zone status for coordinates: lon={lon}, lat={lat}, "
+            f"error: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error checking liquefaction zone status for coordinates: lon={lon}, lat={lat}, "
+            f"error: {str(e)}",
+        )

--- a/backend/api/routers/liquefaction_api.py
+++ b/backend/api/routers/liquefaction_api.py
@@ -71,17 +71,18 @@ async def is_in_liquefaction_zone(
     logger.info(f"Checking liquefaction zone for coordinates: lon={lon}, lat={lat}")
 
     try:
-        query = db.query(LiquefactionZone).filter(
-            LiquefactionZone.geometry.ST_Contains(
-                geo_func.ST_SetSRID(
-                    geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326
+        zone = (
+            db.query(LiquefactionZone)
+            .filter(
+                LiquefactionZone.geometry.ST_Contains(
+                    geo_func.ST_SetSRID(
+                        geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326
+                    )
                 )
             )
+            .first()
         )
-
-        exists = db.query(query.exists()).scalar()
-
-        zone = query.first() if exists else None
+        exists = zone is not None
         last_updated = zone.update_timestamp if zone else None
 
         logger.info(

--- a/backend/api/routers/soft_story_api.py
+++ b/backend/api/routers/soft_story_api.py
@@ -72,13 +72,16 @@ async def is_soft_story(lon: float, lat: float, db: Session = Depends(get_db)):
     logger.info(f"Checking soft story status for coordinates: lon={lon}, lat={lat}")
 
     try:
-        query = db.query(SoftStoryProperty).filter(
-            SoftStoryProperty.point
-            == geo_func.ST_GeomFromText(f"POINT({lon} {lat})", 4326)
+        property = (
+            db.query(SoftStoryProperty)
+            .filter(
+                SoftStoryProperty.point
+                == geo_func.ST_GeomFromText(f"POINT({lon} {lat})", 4326)
+            )
+            .first()
         )
 
-        exists = db.query(query.exists()).scalar()
-        property = query.first() if exists else None
+        exists = property is not None
         last_updated = property.update_timestamp if property else None
 
         logger.info(

--- a/backend/api/routers/soft_story_api.py
+++ b/backend/api/routers/soft_story_api.py
@@ -8,8 +8,15 @@ from geoalchemy2 import functions as geo_func
 from backend.api.schemas.soft_story_schemas import (
     SoftStoryFeature,
     SoftStoryFeatureCollection,
+    IsSoftStoryPropertyView,
 )
 from backend.api.models.soft_story_properties import SoftStoryProperty
+import logging
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/api/soft-stories",
@@ -36,18 +43,21 @@ async def get_soft_stories(db: Session = Depends(get_db)):
     soft_stories = (
         db.query(SoftStoryProperty).filter(SoftStoryProperty.point.isnot(None)).all()
     )
+
     # If no soft story properties are found, raise a 404 error
     if not soft_stories:
+        logger.warning("No soft story properties found in database")
         raise HTTPException(status_code=404, detail="No soft stories found")
 
     features = [SoftStoryFeature.from_sqlalchemy_model(story) for story in soft_stories]
+    logger.info(f"Successfully retrieved {len(features)} soft story properties")
     return SoftStoryFeatureCollection(type="FeatureCollection", features=features)
 
 
-@router.get("/is-soft-story", response_model=bool)
+@router.get("/is-soft-story", response_model=IsSoftStoryPropertyView)
 async def is_soft_story(lon: float, lat: float, db: Session = Depends(get_db)):
     """
-    Checks if a point is a soft story property
+    Checks if a point is a soft story property and returns its last update time
 
     Args:
         lon (float): Longitude of the point
@@ -55,10 +65,38 @@ async def is_soft_story(lon: float, lat: float, db: Session = Depends(get_db)):
         db (Session): The database session dependency
 
     Returns:
-        bool: True if the point is a soft story property, False
-        otherwise
+        IsSoftStoryPropertyView containing:
+        - exists: True if point is in a soft story property
+        - last_updated: Timestamp of last update if exists, None otherwise
     """
-    query = db.query(SoftStoryProperty).filter(
-        SoftStoryProperty.point == geo_func.ST_GeomFromText(f"POINT({lon} {lat})", 4326)
-    )
-    return db.query(query.exists()).scalar()
+    logger.info(f"Checking soft story status for coordinates: lon={lon}, lat={lat}")
+
+    try:
+        query = db.query(SoftStoryProperty).filter(
+            SoftStoryProperty.point
+            == geo_func.ST_GeomFromText(f"POINT({lon} {lat})", 4326)
+        )
+
+        exists = db.query(query.exists()).scalar()
+        property = query.first() if exists else None
+        last_updated = property.update_timestamp if property else None
+
+        logger.info(
+            f"Soft story check result for coordinates: lon={lon}, lat={lat} - "
+            f"exists: {exists}, "
+            f"last_updated: {last_updated}"
+        )
+
+        return IsSoftStoryPropertyView(exists=exists, last_updated=last_updated)
+
+    except Exception as e:
+        logger.error(
+            f"Error checking soft story status for coordinates: lon={lon}, lat={lat}, "
+            f"error: {str(e)}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error checking soft story status for coordinates: lon={lon}, lat={lat}, "
+            f"error: {str(e)}",
+        )

--- a/backend/api/routers/tsunami_api.py
+++ b/backend/api/routers/tsunami_api.py
@@ -68,17 +68,19 @@ async def is_in_tsunami_zone(lon: float, lat: float, db: Session = Depends(get_d
     logger.info(f"Checking tsunami zone for coordinates: lon={lon}, lat={lat}")
 
     try:
-        query = db.query(TsunamiZone).filter(
-            TsunamiZone.geometry.ST_Contains(
-                geo_func.ST_SetSRID(
-                    geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326
+        zone = (
+            db.query(TsunamiZone)
+            .filter(
+                TsunamiZone.geometry.ST_Contains(
+                    geo_func.ST_SetSRID(
+                        geo_func.ST_GeomFromText(f"POINT({lon} {lat})"), 4326
+                    )
                 )
             )
+            .first()
         )
 
-        exists = db.query(query.exists()).scalar()
-
-        zone = query.first() if exists else None
+        exists = zone is not None
         last_updated = zone.update_timestamp if zone else None
 
         logger.info(

--- a/backend/api/schemas/liquefaction_schemas.py
+++ b/backend/api/schemas/liquefaction_schemas.py
@@ -1,8 +1,8 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from backend.api.models.liquefaction_zones import LiquefactionZone
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon
 from geoalchemy2.shape import to_shape
-from typing import List
+from typing import List, Optional
 import json
 from datetime import datetime
 
@@ -71,3 +71,18 @@ class LiquefactionFeatureCollection(FeatureCollection):
 
     type: str = Field(default="FeatureCollection")  # type: ignore
     features: List[LiquefactionFeature]
+
+
+class IsInLiquefactionZoneView(BaseModel):
+    """
+    Pydantic View model for liquefaction zone check endpoint.
+
+    Attributes:
+        exists (bool): Whether the point is in a liquefaction zone
+        last_updated (Optional[datetime]): Timestamp of last update if exists
+    """
+
+    exists: bool
+    last_updated: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/api/schemas/soft_story_schemas.py
+++ b/backend/api/schemas/soft_story_schemas.py
@@ -1,9 +1,8 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from backend.api.models.soft_story_properties import SoftStoryProperty
 from geojson_pydantic import Feature, FeatureCollection, Point
 from geoalchemy2.shape import to_shape
-from typing import List
-import json
+from typing import List, Optional
 from datetime import datetime
 
 
@@ -73,3 +72,17 @@ class SoftStoryFeatureCollection(FeatureCollection):
 
     type: str = Field(default="FeatureCollection")  # type: ignore
     features: List[SoftStoryFeature]
+
+
+class IsSoftStoryPropertyView(BaseModel):
+    """Pydantic view model for soft story property check endpoint.
+
+    Attributes:
+        exists (bool): Whether the point is in a soft story property
+        last_updated (Optional[datetime]): Timestamp of last update if exists
+    """
+
+    exists: bool
+    last_updated: Optional[datetime]
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/api/schemas/tsunami_schemas.py
+++ b/backend/api/schemas/tsunami_schemas.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from backend.api.models.tsunami import TsunamiZone
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon
-from typing import List
+from typing import List, Optional
 import json
 from datetime import datetime
 
@@ -70,3 +70,18 @@ class TsunamiFeatureCollection(FeatureCollection):
 
     type: str = Field(default="FeatureCollection")  # type: ignore
     features: List[TsunamiFeature]
+
+
+class IsInTsunamiZoneView(BaseModel):
+    """
+    Pydantic View model for tsunami zone check endpoint.
+
+    Attributes:
+        exists (bool): Whether the point is in a tsunami zone
+        last_updated (Optional[datetime]): Timestamp of last update if exists
+    """
+
+    exists: bool
+    last_updated: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/api/tests/test_liquefaction.py
+++ b/backend/api/tests/test_liquefaction.py
@@ -1,4 +1,5 @@
 from backend.api.tests.test_session_config import test_engine, test_session, client
+import logging
 
 
 def test_get_liquefaction_zones(client):
@@ -8,18 +9,37 @@ def test_get_liquefaction_zones(client):
     assert len(response_dict["features"]) == 3
 
 
-def test_is_in_liquefaction_zone(client):
+def test_is_in_liquefaction_zone(client, caplog):
+    """Test liquefaction zone check with logging verification"""
+    caplog.set_level(logging.INFO)
+
+    # Test point in liquefaction zone
     lon, lat = [-122.35, 37.83]
     response = client.get(
         f"api/liquefaction-zones/is-in-liquefaction-zone?lon={lon}&lat={lat}"
     )
-    assert response.status_code == 200
-    assert response.json()  # True
 
-    # These should not be in liquefaction zones
+    assert response.status_code == 200
+    assert response.json()["exists"]
+    assert response.json()["last_updated"] is not None
+    assert (
+        f"Checking liquefaction zone for coordinates: lon={lon}, lat={lat}"
+        in caplog.text
+    )
+    assert "Liquefaction zone check result" in caplog.text
+    assert f"exists: {response.json()['exists']}" in caplog.text
+
+    # Test point not in liquefaction zone
     wrong_lon, wrong_lat = [0.0, 0.0]
     response = client.get(
         f"api/liquefaction-zones/is-in-liquefaction-zone?lon={wrong_lon}&lat={wrong_lat}"
     )
+
     assert response.status_code == 200
-    assert not response.json()  # False
+    assert not response.json()["exists"]
+    assert response.json()["last_updated"] is None
+    assert (
+        f"Checking liquefaction zone for coordinates: lon={wrong_lon}, lat={wrong_lat}"
+        in caplog.text
+    )
+    assert "exists: False" in caplog.text

--- a/backend/api/tests/test_soft_story.py
+++ b/backend/api/tests/test_soft_story.py
@@ -1,4 +1,5 @@
 from backend.api.tests.test_session_config import test_engine, test_session, client
+import logging
 
 
 def test_get_soft_stories(client):
@@ -8,16 +9,35 @@ def test_get_soft_stories(client):
     assert len(response_dict["features"]) == 6
 
 
-def test_is_soft_story(client):
+def test_is_soft_story(client, caplog):
+    """Test soft story check with logging verification"""
+    caplog.set_level(logging.INFO)
+
+    # Test existing soft story
     lon, lat = [-122.424968, 37.76293]
     response = client.get(f"api/soft-stories/is-soft-story?lon={lon}&lat={lat}")
-    assert response.status_code == 200
-    assert response.json()  # True
 
-    # These should not be soft stories
+    assert response.status_code == 200
+    assert response.json()["exists"]
+    assert response.json()["last_updated"] is not None
+    assert (
+        f"Checking soft story status for coordinates: lon={lon}, lat={lat}"
+        in caplog.text
+    )
+    assert "Soft story check result" in caplog.text
+    assert f"exists: {response.json()['exists']}" in caplog.text
+
+    # Test non-existent soft story
     wrong_lon, wrong_lat = [0.0, 0.0]
     response = client.get(
         f"api/soft-stories/is-soft-story?lon={wrong_lon}&lat={wrong_lat}"
     )
+
     assert response.status_code == 200
-    assert not response.json()  # False
+    assert not response.json()["exists"]
+    assert response.json()["last_updated"] is None
+    assert (
+        f"Checking soft story status for coordinates: lon={wrong_lon}, lat={wrong_lat}"
+        in caplog.text
+    )
+    assert "exists: False" in caplog.text

--- a/backend/api/tests/test_tsunami.py
+++ b/backend/api/tests/test_tsunami.py
@@ -1,4 +1,5 @@
 from backend.api.tests.test_session_config import test_session, test_engine, client
+import logging
 
 
 def test_get_tsunami_zones(client):
@@ -8,16 +9,32 @@ def test_get_tsunami_zones(client):
     assert len(response_dict["features"]) == 1
 
 
-def test_is_in_tsunami_zone(client):
-    lon, lat = [-122.4, 37.75]
-    response = client.get(f"api/tsunami-zones/is-in-tsunami-zone?lon={lon}&lat={lat}")
-    assert response.status_code == 200
-    assert response.json()  # True
+def test_is_in_tsunami_zone(client, caplog):
+    """Test tsunami zone check with logging verification"""
+    caplog.set_level(logging.INFO)
 
-    # These should not be in our tsunami zone
+    # Test point in tsunami zone
+    lon, lat = [-122.35, 37.83]
+    response = client.get(f"api/tsunami-zones/is-in-tsunami-zone?lon={lon}&lat={lat}")
+
+    assert response.status_code == 200
+    assert response.json()["exists"]
+    assert response.json()["last_updated"] is not None
+    assert f"Checking tsunami zone for coordinates: lon={lon}, lat={lat}" in caplog.text
+    assert "Tsunami zone check result" in caplog.text
+    assert f"exists: {response.json()['exists']}" in caplog.text
+
+    # Test point not in tsunami zone
     wrong_lon, wrong_lat = [0.0, 0.0]
     response = client.get(
         f"api/tsunami-zones/is-in-tsunami-zone?lon={wrong_lon}&lat={wrong_lat}"
     )
+
     assert response.status_code == 200
-    assert not response.json()  # False
+    assert not response.json()["exists"]
+    assert response.json()["last_updated"] is None
+    assert (
+        f"Checking tsunami zone for coordinates: lon={wrong_lon}, lat={wrong_lat}"
+        in caplog.text
+    )
+    assert "exists: False" in caplog.text

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
# Description
Each hazard card needs a timestamp, so return the last updated timestamp for a given set of coordinates if they're in a hazard zone.

Tested by invoking the apis on localhost:8000/docs:

`is-soft-story`:
Backend service logs:
backend-1           | 2025-02-13 04:16:09,310 - backend.api.routers.soft_story_api - INFO - Checking soft story status for coordinates: lon=-122.424968, lat=37.76293
backend-1           | 2025-02-13 04:16:09,488 - backend.api.routers.soft_story_api - INFO - Soft story check result for coordinates: lon=-122.424968, lat=37.76293 - exists: True, last_updated: 2025-02-13 04:14:54.478894+00:00
backend-1           | INFO:     172.18.0.1:58282 - "GET /api/soft-stories/is-soft-story?lon=-122.424968&lat=37.76293 HTTP/1.1" 200 OK

`is-liquefaction-zone`:
backend-1           | 2025-02-13 04:46:51,896 - backend.api.routers.liquefaction_api - INFO - Checking liquefaction zone for coordinates: lon=-122.35, lat=37.83
backend-1           | 2025-02-13 04:46:52,085 - backend.api.routers.liquefaction_api - INFO - Liquefaction zone check result for coordinates: lon=-122.35, lat=37.83 - exists: False, last_updated: None
backend-1           | INFO:     172.18.0.1:52948 - "GET /api/liquefaction-zones/is-in-liquefaction-zone?lon=-122.35&lat=37.83 HTTP/1.1" 200 OK

`is-in-tsunami-zone`:
backend-1           | 2025-02-13 05:06:35,171 - backend.api.routers.tsunami_api - INFO - Checking tsunami zone for coordinates: lon=-122.4, lat=37.75
backend-1           | 2025-02-13 05:06:35,201 - backend.api.routers.tsunami_api - INFO - Tsunami zone check result for coordinates: lon=-122.4, lat=37.75 - exists: True, last_updated: 2025-02-13 05:05:55.241333+00:00
backend-1           | INFO:     172.18.0.1:57642 - "GET /api/tsunami-zones/is-in-tsunami-zone?lon=-122.4&lat=37.75 HTTP/1.1" 200 OK

https://github.com/sfbrigade/datasci-earthquake/issues/223

## Type of changes
- [ ] Bugfix
- [ ] Chore
- [x] New Feature

## Testing
- [x] I updated automated tests
- [ ] I think tests are unnecessary

## How to test

Unit test
1. docker-compose up
2. docker exec -it datasci-earthquake-backend-1 /bin/bash
3. pytest backend/api/test/test_{liquefaction, soft_story, tsunami}.py
4. Ensure all the tests succeed.

Api
1. docker-compose up
2. Go to localhost:8000/docs
3. Test out the `is-*` apis. Use the `lon, lat` values from their unit test data.
5. Ensure the returned response contains the `last_updated` timestamp.
6. Optionally, check the backend service logs on docker.

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)