### PR TITLE
Use loading skeleton as fallback UI for main page to reduce perceived load time

### DIFF
--- a/app/home-skeleton.tsx
+++ b/app/home-skeleton.tsx
@@ -1,0 +1,32 @@
+import "./globals.css";
+import { FeatureCollection, GeoJsonProperties, Geometry } from "geojson";
+
+import AddressMapper from "./components/address-mapper";
+import { Headings } from "./data/data";
+
+const HomeSkeleton = () => {
+  const headingData = Headings.home;
+  let softStoryData: FeatureCollection<Geometry, GeoJsonProperties> = {
+    type: "FeatureCollection",
+    features: [],
+  };
+  let tsunamiData: FeatureCollection<Geometry, GeoJsonProperties> = {
+    type: "FeatureCollection",
+    features: [],
+  };
+  let liquefactionData: FeatureCollection<Geometry, GeoJsonProperties> = {
+    type: "FeatureCollection",
+    features: [],
+  };
+
+  return (
+    <AddressMapper
+      headingData={headingData}
+      softStoryData={softStoryData}
+      tsunamiData={tsunamiData}
+      liquefactionData={liquefactionData}
+    />
+  );
+};
+
+export default HomeSkeleton;

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,4 @@
+import HomeSkeleton from "./home-skeleton";
+export default function Loading() {
+  return <HomeSkeleton />;
+}


### PR DESCRIPTION
# Description

Loading skeleton loaded by `loading.tsx` so that static UI appears while waiting for API calls to return. Perceived loading time is reduced due to early UI rendering.

Closes #284

## Type of changes
- [ ] Bugfix
- [x] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

1. Wipe the browser cache
2. Load app locally (or preview app). Observe sections of page load immediately, and then the map loads later.
3. Load app in production (https://safehome.report) or from current main branch. Observe how several seconds pass before any of the page is rendered, in contrast to this branch's deployment.

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)