### PR TITLE
Opt into server-side caching with a revalidation period of 24 hours

### DIFF
--- a/app/api/fetch-data.ts
+++ b/app/api/fetch-data.ts
@@ -1,7 +1,9 @@
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
 export const fetchData = async (cdnEndpoint: string, apiEndpoint: string) => {
   try {
     // Try fetching from CDN first
-    const cdnResponse = await fetch(cdnEndpoint, { cache: "no-store" });
+    const cdnResponse = await fetch(cdnEndpoint, { next: { revalidate: SECONDS_PER_DAY } });
     if (cdnResponse.ok) {
       return await cdnResponse.json();
     } else {
@@ -11,11 +13,10 @@ export const fetchData = async (cdnEndpoint: string, apiEndpoint: string) => {
     console.warn(`CDN fetch error: ${error.message}. Falling back to API.`);
   }
 
+  // TODO: prevent this fallback from running if the CDN call successfully returns valid data
   // Fallback to API
   try {
-    const apiResponse = await fetch(apiEndpoint, {
-      cache: 'no-store',
-    });
+    const apiResponse = await fetch(apiEndpoint, { next: { revalidate: SECONDS_PER_DAY } });
     if (!apiResponse.ok) {
       switch (apiResponse.status) {
         case 404:


### PR DESCRIPTION
# Description

Turn on server-side caching for the initial API calls. Revalidate cache every 24 hours. This will improve initial load time of the map layer data (soft stories, seismic and tsunami polygons) after the first visit (by any visitor, doesn't need to be current user).

The end result will mean the map itself loads more quickly AND the layer data on top of it since the map rendering is currently blocked until data is received. Receiving the data more quickly enables the speedup.

Closes #279

## Type of changes
- [ ] Bugfix
- [x] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

1. Clear browser cache
2. Visit app locally or preview app in browser
3. Observe slow initial load time of map, including layer data, of several seconds (optionally, check Next logs and observe Next Cache logs show cache MISSES and timings in the several thousands of milliseconds).
2. Reload app in browser
3. Observe faster load time of map, including layer data, ideally sub-second (optionally, check Next logs and observe Next Cache logs show cache HITS and timings now in the hundreds of milliseconds).

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)