### PR TITLE
standardize whitespace across the app with focus on horizontal padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ This repository uses `Black` for Python and `ESLint` for JS/TS to enforce code s
 
 # Configuration of environment variables
 
-We use GitHub Secrets to store sensitive environment variables. A template `.env.example` file is provided in the repository as a reference. Only users with **write** access to the repository can manually trigger the `Generate .env File` workflow, which creates and uploads the **encrypted** `.env` file as an artifact.
+We use GitHub Secrets to store sensitive environment variables. To be able to run the app, users will need **write** access to the repository to manually trigger the `Generate .env File` workflow, which creates and uploads an **encrypted** `.env` file as an artifact.
 
 **Note**: Before starting work on the project, make sure to:
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -37,7 +37,7 @@ const About = () => {
   const buildTeamMembers = () => {
     return TeamMembers.map((teamMember) => {
       return (
-        <ListItem key={teamMember.id} mb="5px">
+        <ListItem key={teamMember.id} mb="4px">
           <Text>
             <Text as="span" fontWeight={800}>
               {teamMember.name}
@@ -54,15 +54,15 @@ const About = () => {
     <Flex
       w={{ base: "base", xl: "xl" }}
       p={{
-        base: "23px 24px 16px 24px",
-        md: "37px 27px 16px 26px",
-        xl: "50px 128px 16px 127px",
+        base: "24px 24px 24px 24px",
+        md: "36px 28px 36px 28px",
+        xl: "80px 128px 80px 128px",
       }}
       direction={{ base: "column", lg: "row" }}
       m="auto"
       gap="46px"
     >
-      <Flex direction="column" alignItems={"flex-start"} gap="50px">
+      <Flex direction="column" alignItems={"flex-start"} gap="48px">
         <Heading headingData={headingData} />
         <Text textStyle="textBig" color="black">
           Seismologists predict a 72% probability that the Bay Area will

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -52,7 +52,7 @@ const About = () => {
 
   return (
     <Flex
-      w={{ base: "base", xl: "xl" }}
+      w={{ base: "full", xl: "7xl" }}
       p={{
         base: "24px 24px 24px 24px",
         md: "36px 28px 36px 28px",
@@ -60,7 +60,7 @@ const About = () => {
       }}
       direction={{ base: "column", lg: "row" }}
       m="auto"
-      gap="46px"
+      gap="44px"
     >
       <Flex direction="column" alignItems={"flex-start"} gap="48px">
         <Heading headingData={headingData} />

--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -20,7 +20,14 @@ const ComponentsTestLib = () => {
       }}
       m="auto"
     >
-      <Heading as="h1" size="xl" mb={6} bgColor="blue" color="white" p="10px">
+      <Heading
+        as="h1"
+        size="xl"
+        mb={6}
+        bgColor="blueBackground"
+        color="white"
+        p="10px"
+      >
         Components Test Library
       </Heading>
       <Heading as="h2" size="md" mb={3}>

--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -14,9 +14,9 @@ const ComponentsTestLib = () => {
       as="section"
       w={{ base: "base", xl: "xl" }}
       p={{
-        base: "10px 23px 10px 23px",
-        md: "8px 27px 8px 26px",
-        xl: "5px 127px 5px 127px",
+        base: "10px 24px 10px 24px",
+        md: "8px 28px 8px 28px",
+        xl: "6px 128px 6px 128px",
       }}
       m="auto"
     >

--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -20,14 +20,14 @@ const ComponentsTestLib = () => {
       }}
       m="auto"
     >
-      <Heading as="h1" size="xl" mb={4} bgColor="blue" color="white" p="10px">
+      <Heading as="h1" size="xl" mb={6} bgColor="blue" color="white" p="10px">
         Components Test Library
       </Heading>
-      <Heading as="h2" size="md" mb={2}>
+      <Heading as="h2" size="md" mb={3}>
         Search Bar
       </Heading>
-      <Text mb={4}>This section demonstrates the Search Bar component</Text>
-      <VStack spacing={4} align="start">
+      <Text mb={6}>This section demonstrates the Search Bar component</Text>
+      <VStack spacing={6} align="start">
         <HStack w="100%">
           <Box w="400px">
             <SearchBar
@@ -40,29 +40,29 @@ const ComponentsTestLib = () => {
             />
           </Box>
         </HStack>
-        <Divider mb={2} />
+        <Divider mb={3} />
       </VStack>
-      <Heading as="h2" size="md" mb={2}>
+      <Heading as="h2" size="md" mb={3}>
         Hazards Card
       </Heading>
-      <Text mb={4}>This section demonstrates Hazard Card component</Text>
-      <VStack spacing={4} align="start">
+      <Text mb={6}>This section demonstrates Hazard Card component</Text>
+      <VStack spacing={6} align="start">
         <HStack w="100%">{/* <CardHazard hazard={Hazards[0]} /> */}</HStack>
-        <Divider mb={2} />
+        <Divider mb={3} />
       </VStack>
-      <Text mb={4}>This section demonstrates Info Card component</Text>
-      <VStack spacing={4} align="start">
+      <Text mb={6}>This section demonstrates Info Card component</Text>
+      <VStack spacing={6} align="start">
         <HStack w="100%">
           <CardInfo info={Info[0]} />
         </HStack>
-        <Divider mb={2} />
+        <Divider mb={3} />
       </VStack>
-      <Text mb={4}>This section demonstrates Share menu component</Text>
-      <VStack spacing={4} align="start">
+      <Text mb={6}>This section demonstrates Share menu component</Text>
+      <VStack spacing={6} align="start">
         <HStack w="100%">
           <Share />
         </HStack>
-        <Divider mb={2} />
+        <Divider mb={3} />
       </VStack>
     </Box>
   );

--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -12,7 +12,7 @@ const ComponentsTestLib = () => {
   return (
     <Box
       as="section"
-      w={{ base: "base", xl: "xl" }}
+      w={{ base: "full", xl: "7xl" }}
       p={{
         base: "10px 24px 10px 24px",
         md: "8px 28px 8px 28px",

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -105,7 +105,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
         onCoordDataRetrieve={setAddressHazardData}
         onHazardDataLoading={setHazardDataLoading}
       />
-      <Box w="base" h={{ base: "1400px", md: "1000px" }} m="auto">
+      <Box w="full" h={{ base: "1400px", md: "1000px" }} m="auto">
         <Box h="100%" overflow="hidden" position="relative">
           <Box zIndex={10} top={0} position="absolute">
             <ReportHazards
@@ -123,7 +123,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
         </Box>
       </Box>
       <Flex
-        w={{ base: "base", xl: "xl" }}
+        w={{ base: "full", xl: "7xl" }}
         p={{
           base: "24px 24px 24px 24px",
           md: "36px 28px 16px 28px",

--- a/app/components/card-container.tsx
+++ b/app/components/card-container.tsx
@@ -8,7 +8,7 @@ export const CardContainer = ({ children }: { children: React.ReactNode }) => {
         justifyContent="space-between"
         direction={{ base: "column", md: "row" }}
         spacing="16px"
-        w={{ base: "base", xl: "xl" }}
+        w={{ base: "full", xl: "7xl" }}
         px={{ base: "24px", md: "28px", xl: "128px" }}
       >
         {children}

--- a/app/components/card-container.tsx
+++ b/app/components/card-container.tsx
@@ -3,13 +3,13 @@ import { Center, Stack } from "@chakra-ui/react";
 
 export const CardContainer = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Center pb="35px" pt="16px" zIndex={10} w="100vw">
+    <Center pb="36px" pt="16px" zIndex={10} w="100vw">
       <Stack
         justifyContent="space-between"
         direction={{ base: "column", md: "row" }}
-        spacing="15px"
-        w={{ base: "95%", xl: "1100px" }}
-        px={{ base: 0, md: 2 }}
+        spacing="16px"
+        w={{ base: "base", xl: "xl" }}
+        px={{ base: "24px", md: "28px", xl: "128px" }}
       >
         {children}
       </Stack>

--- a/app/components/card-info.tsx
+++ b/app/components/card-info.tsx
@@ -23,7 +23,7 @@ const CardInfo: React.FC<CardInfoProps> = ({
 
   return (
     <BaseCard header={title}>
-      <List styleType="disc" ml={4}>
+      <List styleType="disc" ml={6}>
         {list.map((item) => {
           return (
             <ListItem key={item.id}>

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -18,7 +18,7 @@ const Footer = () => {
   return (
     <Box as="footer" w="100%" bgColor="blue">
       <HStack
-        w={{ base: "base", xl: "xl" }}
+        w={{ base: "full", xl: "7xl" }}
         p={{
           base: "8px 24px 8px 24px",
           md: "14px 28px 14px 28px",

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -16,7 +16,7 @@ const Footer = () => {
   };
 
   return (
-    <Box as="footer" w="100%" bgColor="blue">
+    <Box as="footer" w="100%" bgColor="blueBackground">
       <HStack
         w={{ base: "full", xl: "7xl" }}
         p={{

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -20,9 +20,9 @@ const Footer = () => {
       <HStack
         w={{ base: "base", xl: "xl" }}
         p={{
-          base: "8px 23px 8px 23px",
-          md: "14px 26px 14px 26px",
-          xl: "70px 131px 75px 131px",
+          base: "8px 24px 8px 24px",
+          md: "14px 28px 14px 28px",
+          xl: "72px 128px 72px 128px",
         }}
         justify="space-between"
         m="auto"

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -52,9 +52,7 @@ const Header = () => {
                 md: "28px",
               }}
             />
-            <Text textStyle="logo" color="white">
-              SafeHome
-            </Text>
+            <Text textStyle="logo">SafeHome</Text>
           </HStack>
         </Link>
         {isHome && <Box ref={portalRef} id="searchbar-portal" />}

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -21,7 +21,7 @@ const Header = () => {
     >
       <Stack
         direction={{ base: "column", md: "row" }}
-        w={{ base: "base", xl: "xl" }}
+        w={{ base: "full", xl: "7xl" }}
         h="112px"
         justifyContent="flex-start"
         columnGap="25px"

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -22,14 +22,14 @@ const Header = () => {
       <Stack
         direction={{ base: "column", md: "row" }}
         w={{ base: "base", xl: "xl" }}
-        h="114px"
+        h="112px"
         justifyContent="flex-start"
         columnGap="25px"
         m="auto"
         p={{
-          base: "19px 23px 8px 23px",
-          md: "26px 26px 14px 26px",
-          xl: "29px 127px 13px 127px",
+          base: "18px 24px 18px 24px",
+          md: "28px 28px 28px 28px",
+          xl: "28px 128px 28px 128px",
         }}
       >
         <Link
@@ -48,7 +48,7 @@ const Header = () => {
               alt="Logo"
               color="white"
               boxSize={{
-                base: "22px",
+                base: "24px",
                 md: "28px",
               }}
             />

--- a/app/components/home-header.tsx
+++ b/app/components/home-header.tsx
@@ -34,14 +34,14 @@ const HomeHeader = ({
   return (
     <Box
       bg="gradient.blue"
-      paddingTop={{ base: "57px", md: "76px", xl: "78px" }}
+      paddingTop={{ base: "56px", md: "72px", xl: "80px" }}
     >
       <Box
         w={{ base: "base", xl: "xl" }}
         p={{
-          base: "35px 23px 40px 23px",
-          md: "42px 26px 46px 26px",
-          xl: "24px 127px 24px 127px",
+          base: "36px 24px 40px 24px",
+          md: "44px 28px 44px 28px",
+          xl: "24px 128px 24px 128px",
         }}
         margin="auto"
       >

--- a/app/components/home-header.tsx
+++ b/app/components/home-header.tsx
@@ -37,7 +37,7 @@ const HomeHeader = ({
       paddingTop={{ base: "56px", md: "72px", xl: "80px" }}
     >
       <Box
-        w={{ base: "base", xl: "xl" }}
+        w={{ base: "full", xl: "7xl" }}
         p={{
           base: "36px 24px 40px 24px",
           md: "44px 28px 44px 28px",

--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -194,7 +194,6 @@ const Map: React.FC<MapProps> = ({
       {debug === "true" && (
         <span
           style={{
-            backgroundColor: "pink",
             position: "absolute",
             top: 0,
             right: 0,

--- a/app/components/report-hazards.tsx
+++ b/app/components/report-hazards.tsx
@@ -43,7 +43,7 @@ const ReportHazards = ({
         alignItems="center"
       >
         <Stack
-          w={{ base: "base", xl: "xl" }}
+          w={{ base: "full", xl: "7xl" }}
           px={{
             base: "24px",
             md: "28px",

--- a/app/components/report-hazards.tsx
+++ b/app/components/report-hazards.tsx
@@ -45,9 +45,9 @@ const ReportHazards = ({
         <Stack
           w={{ base: "base", xl: "xl" }}
           px={{
-            base: "23px",
-            md: "26px",
-            xl: "127px",
+            base: "24px",
+            md: "28px",
+            xl: "128px",
           }}
           spacing={{ base: 1, md: 5 }}
           direction={{ base: "column", md: "row" }}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -9,7 +9,7 @@ const customTheme = extendTheme({
     logo: {
       fontSize: "lg",
       fontWeight: "300",
-      color: "blue",
+      color: "white",
       fontFamily: "heading",
     },
     headerBig: {
@@ -59,13 +59,6 @@ const customTheme = extendTheme({
     textSemibold: {
       fontWeight: "600",
     },
-    linkBig: {
-      fontSize: "xl",
-      fontWeight: "normal",
-      color: "blue",
-      textDecoration: "underline",
-      fontFamily: "body",
-    },
     list: {
       listStyleType: "disc",
       paddingLeft: "6",
@@ -82,9 +75,10 @@ const customTheme = extendTheme({
       900: "#171923",
     },
     white: "#FFF",
-    blue: "#2C5282",
-    lightBlue: "#3182CE",
-    tsunamiBlue: "#63B3ED",
+    blueBackground: "#2C5282", // blue/700
+    blue: "#2B6CB0", // blue/600 (TODO: all headings)
+    lightBlue: "#3182CE", // blue/500 (TODO: remove)
+    tsunamiBlue: "#63B3ED", // blue/300
     yellow: "#ECC94B",
     red: "#C53030",
     green: "#25855A",
@@ -93,20 +87,35 @@ const customTheme = extendTheme({
     gradient: {
       blue: "radial-gradient(120% 180% at 17.81% 82.6%, rgba(59,98,148,1) 0%, rgba(24,50,82,1) 100%);",
     },
-    sizes: {
-      base: "100%",
-      sm: "375px",
-      md: "744px",
-      xl: "1280px",
-    },
-    breakpoints: {
-      base: "0px",
-      sm: "375px",
-      md: "744px",
-      lg: "992px",
-      xl: "1280px",
-      "2xl": "1536px",
-    },
+  },
+  sizes: {
+    // // originals
+    // sm: "24rem", // 384px
+    // md: "28rem", // 448px
+    // lg: "32rem", // 512px, not overridden
+    // xl: "36rem", // 576px
+    // overrides
+    base: "100%", // new
+    sm: "375px", // 375px (vs 384px) !== // xs?
+    md: "744px", // 744px (vs 448px) !==
+    // lg: "512px", // 512px, not overridden ==
+    xl: "1280px", // 1280px (vs 576px) !== // xl?
+  },
+  breakpoints: {
+    // // originals
+    // base: "0em", // 0px
+    // sm: "30em", // 480px
+    // md: "48em", // 768px
+    // lg: "62em", // 992px
+    // xl: "80em", // 1280px
+    // "2xl": "96em", // 1536px
+    // overrides
+    base: "0px", // 0px
+    sm: "375px", // 375px (vs 480px) !=
+    md: "744px", // 744px (vs 768px) !=
+    lg: "992px", // 992px (vs 992px) ==
+    xl: "1280px", // 1280px (vs 1280px) ==
+    "2xl": "1536px", // 1536px (vs 1536px) ==
   },
 });
 

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -7,7 +7,7 @@ const customTheme = extendTheme({
   },
   textStyles: {
     logo: {
-      fontSize: ["xl", "xl", "2xl", "2xl", "2xl", "2xl"],
+      fontSize: "lg",
       fontWeight: "300",
       color: "blue",
       fontFamily: "heading",
@@ -93,25 +93,6 @@ const customTheme = extendTheme({
     gradient: {
       blue: "radial-gradient(120% 180% at 17.81% 82.6%, rgba(59,98,148,1) 0%, rgba(24,50,82,1) 100%);",
     },
-  },
-  space: {
-    12: "128px",
-    4: "24px",
-    2: "12px",
-  },
-  sizes: {
-    base: "100%",
-    sm: "375px",
-    md: "744px",
-    xl: "1280px",
-  },
-  breakpoints: {
-    base: "0px",
-    sm: "375px",
-    md: "744px",
-    lg: "992px",
-    xl: "1280px",
-    "2xl": "1536px",
   },
 });
 

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -93,6 +93,20 @@ const customTheme = extendTheme({
     gradient: {
       blue: "radial-gradient(120% 180% at 17.81% 82.6%, rgba(59,98,148,1) 0%, rgba(24,50,82,1) 100%);",
     },
+    sizes: {
+      base: "100%",
+      sm: "375px",
+      md: "744px",
+      xl: "1280px",
+    },
+    breakpoints: {
+      base: "0px",
+      sm: "375px",
+      md: "744px",
+      lg: "992px",
+      xl: "1280px",
+      "2xl": "1536px",
+    },
   },
 });
 


### PR DESCRIPTION
# Description

> NOTE: Please merge bottom card replacement PR #344 first.

This PR addresses feedback on whitespace. It also uses Chakra theme defaults where custom ones appear unnecessary.

Lastly, it adjusts the blue heading colors.

## Type of changes
- [ ] Bugfix
- [x] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

Compare latest deployment (scroll to bottom and look for the last "View Deployment" link) to prod site at different breakpoints. Also compare to [Figma desktop versions](https://www.figma.com/design/PV3mZIbiGI1mxHHGOPeOqx/SafeHome-Design--20250325-Copy-?node-id=2082-809) (mobile versions are forthcoming).

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)