### PR TITLE
cooperativeGestures added

### DIFF
--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -55,6 +55,7 @@ const Map: React.FC<MapProps> = ({
         touchPitch: false, // turn off pitch change w/touch
         touchZoomRotate: true, // turn on zoom/rotate w/touch
         keyboard: true, // turn on keyboard shortcuts
+        cooperativeGestures: true, // scroll-to-zoom requires using the control or command key while scrolling to zoom the map
         config: {
           // Initial configuration for the Mapbox Standard style set above. By default, its ID is `basemap`.
           basemap: {


### PR DESCRIPTION
# Description

Added cooperative gestures to the map to prevent scrolling from being blocked by zoom. Now, zooming requires holding an additional key.

#229 

## Type of changes
- [ ] Bugfix
- [ ] Chore
- [x] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test
Open the web application and try scrolling the map. The map appears dimmed, and a message prompts you to press and hold an additional key to scroll.

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)