### PR TITLE
Handle address search errors

### DIFF
--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -35,6 +35,7 @@ const ComponentsTestLib = () => {
               onSearchChange={() => {}}
               onAddressSearch={() => {}}
               onCoordDataRetrieve={() => {}}
+              onHazardDataLoading={() => {}}
             />
           </Box>
         </HStack>

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -33,7 +33,10 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
 }) => {
   const [coordinates, setCoordinates] = useState(defaultCoords);
   const [searchedAddress, setSearchedAddress] = useState("");
-  const [addressHazardData, setAddressHazardData] = useState<any[]>([]);
+  const [addressHazardData, setAddressHazardData] = useState<any[] | undefined>(
+    undefined
+  );
+  const [isHazardDataLoading, setHazardDataLoading] = useState(false);
 
   const updateMap = (coords: number[]) => {
     setCoordinates(coords);
@@ -46,6 +49,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
         onSearchChange={updateMap}
         onAddressSearch={setSearchedAddress}
         onCoordDataRetrieve={setAddressHazardData}
+        onHazardDataLoading={setHazardDataLoading}
       />
       <Box w="base" h={{ base: "1400px", md: "1000px" }} m="auto">
         <Box h="100%" overflow="hidden" position="relative">
@@ -53,6 +57,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
             <Report
               searchedAddress={searchedAddress}
               addressHazardData={addressHazardData}
+              isHazardDataLoading={isHazardDataLoading}
             />
           </Box>
           <Map

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -33,9 +33,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
 }) => {
   const [coordinates, setCoordinates] = useState(defaultCoords);
   const [searchedAddress, setSearchedAddress] = useState("");
-  const [addressHazardData, setAddressHazardData] = useState<object | undefined>(
-    undefined
-  );
+  const [addressHazardData, setAddressHazardData] = useState<object>({});
   const [isHazardDataLoading, setHazardDataLoading] = useState(false);
 
   const updateMap = (coords: number[]) => {

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -33,7 +33,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
 }) => {
   const [coordinates, setCoordinates] = useState(defaultCoords);
   const [searchedAddress, setSearchedAddress] = useState("");
-  const [addressHazardData, setAddressHazardData] = useState<any[] | undefined>(
+  const [addressHazardData, setAddressHazardData] = useState<object | undefined>(
     undefined
   );
   const [isHazardDataLoading, setHazardDataLoading] = useState(false);

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -36,9 +36,14 @@ interface CardHazardProps {
     exists?: boolean;
     last_updated?: string;
   };
+  showData: boolean;
 }
 
-const CardHazard: React.FC<CardHazardProps> = ({ hazard, hazardData }) => {
+const CardHazard: React.FC<CardHazardProps> = ({
+  hazard,
+  hazardData,
+  showData,
+}) => {
   const { title, name, description } = hazard;
   const { exists, last_updated: date } = hazardData || {};
 
@@ -75,7 +80,7 @@ const CardHazard: React.FC<CardHazardProps> = ({ hazard, hazardData }) => {
                 <Text cursor={"pointer"} textDecoration={"underline"}>
                   More Info
                 </Text>
-                {exists !== undefined ? <Pill exists={exists} /> : ""}
+                {showData ? <Pill exists={exists} /> : ""}
               </HStack>
             </CardFooter>
           </VStack>

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -9,6 +9,7 @@ import {
   Card,
   CardHeader,
   useDisclosure,
+  Spinner,
 } from "@chakra-ui/react";
 import Pill from "./pill";
 import {
@@ -37,12 +38,14 @@ interface CardHazardProps {
     last_updated?: string;
   };
   showData: boolean;
+  isHazardDataLoading: boolean;
 }
 
 const CardHazard: React.FC<CardHazardProps> = ({
   hazard,
   hazardData,
   showData,
+  isHazardDataLoading,
 }) => {
   const { title, name, description } = hazard;
   const { exists, last_updated: date } = hazardData || {};
@@ -55,6 +58,16 @@ const CardHazard: React.FC<CardHazardProps> = ({
         ))}
       </VStack>
     );
+  };
+
+  const buildHazardPill = () => {
+    if (isHazardDataLoading) {
+      return <Spinner size="xs" />;
+    } else if (showData) {
+      return <Pill exists={exists} />;
+    } else {
+      return "";
+    }
   };
 
   return (
@@ -80,7 +93,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
                 <Text cursor={"pointer"} textDecoration={"underline"}>
                   More Info
                 </Text>
-                {showData ? <Pill exists={exists} /> : ""}
+                {buildHazardPill()}
               </HStack>
             </CardFooter>
           </VStack>

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -50,6 +50,14 @@ const CardHazard: React.FC<CardHazardProps> = ({
   const { title, name, description } = hazard;
   const { exists, last_updated: date } = hazardData || {};
 
+  const hazardPill = isHazardDataLoading ? (
+    <Spinner size="xs" />
+  ) : showData ? (
+    <Pill exists={exists} />
+  ) : (
+    ""
+  );
+
   const buildHazardCardInfo = () => {
     return (
       <VStack gap={5} p={5}>
@@ -58,16 +66,6 @@ const CardHazard: React.FC<CardHazardProps> = ({
         ))}
       </VStack>
     );
-  };
-
-  const buildHazardPill = () => {
-    if (isHazardDataLoading) {
-      return <Spinner size="xs" />;
-    } else if (showData) {
-      return <Pill exists={exists} />;
-    } else {
-      return "";
-    }
   };
 
   return (
@@ -93,7 +91,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
                 <Text cursor={"pointer"} textDecoration={"underline"}>
                   More Info
                 </Text>
-                {buildHazardPill()}
+                {hazardPill}
               </HStack>
             </CardFooter>
           </VStack>

--- a/app/components/home-header.tsx
+++ b/app/components/home-header.tsx
@@ -10,6 +10,7 @@ interface HomeHeaderProps {
   onSearchChange: (coords: number[]) => void;
   onAddressSearch: (address: string) => void;
   onCoordDataRetrieve: (data: any[]) => void;
+  onHazardDataLoading: (isLoading: boolean) => void;
 }
 
 const HomeHeader = ({
@@ -17,6 +18,7 @@ const HomeHeader = ({
   onSearchChange,
   onAddressSearch,
   onCoordDataRetrieve,
+  onHazardDataLoading,
 }: HomeHeaderProps) => {
   const headingData = Headings.home;
 
@@ -44,6 +46,7 @@ const HomeHeader = ({
           onSearchChange={onSearchChange}
           onAddressSearch={onAddressSearch}
           onCoordDataRetrieve={onCoordDataRetrieve}
+          onHazardDataLoading={onHazardDataLoading}
         />
       </Box>
     </Box>

--- a/app/components/pill.tsx
+++ b/app/components/pill.tsx
@@ -1,23 +1,41 @@
 import { Box, Text } from "@chakra-ui/react";
-import { AddressData, AddressDataType } from "./__mocks__/address-data";
 
 interface PillProps {
   exists: boolean | undefined;
 }
 
 const Pill: React.FC<PillProps> = ({ exists }) => {
-  const color = exists ? "red" : "green";
-  const status = exists ? "At Risk" : "Low Risk";
+  const getColor = () => {
+    switch (exists) {
+      case true:
+        return "red";
+      case false:
+        return "green";
+      default:
+        return "grey";
+    }
+  };
+
+  const getLabel = () => {
+    switch (exists) {
+      case true:
+        return "At Risk";
+      case false:
+        return "Low Risk";
+      default:
+        return "No Data";
+    }
+  };
 
   return (
     <Box>
       <Text
-        bgColor={color}
+        bgColor={getColor()}
         color="white"
         p="2px 12px 2px 12px"
         borderRadius="25"
       >
-        {status}
+        {getLabel()}
       </Text>
     </Box>
   );

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -17,8 +17,8 @@ import { KeyElem } from "./key-elem";
 
 type HazardData = {
   softStory?: any;
-  tsunamiZone?: any;
-  liquefactionZone?: any;
+  tsunami?: any;
+  liquefaction?: any;
 };
 
 const Report = ({

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -30,6 +30,8 @@ const Report = ({
   addressHazardData: HazardData;
   isHazardDataLoading: boolean;
 }) => {
+  const hazardData = "";
+
   return (
     <Center flexDirection="column">
       <Collapse
@@ -121,7 +123,7 @@ const Report = ({
         </Stack>
       </Box>
       <CardContainer>
-        {Hazards.map((hazard, index) => {
+        {Hazards.map((hazard) => {
           return (
             <CardHazard
               key={hazard.id}
@@ -130,7 +132,6 @@ const Report = ({
                 addressHazardData?.[hazard.name as keyof HazardData] ??
                 undefined
               }
-              // showData={addressHazardData?.[hazard.name as keyof HazardData] ? true : false}
               showData={hazard.name in addressHazardData ? true : false}
               isHazardDataLoading={isHazardDataLoading}
             />

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -127,7 +127,8 @@ const Report = ({
               key={hazard.id}
               hazard={hazard}
               hazardData={
-                addressHazardData?.[hazard.name as keyof HazardData] ?? undefined
+                addressHazardData?.[hazard.name as keyof HazardData] ??
+                undefined
               }
               // showData={addressHazardData?.[hazard.name as keyof HazardData] ? true : false}
               showData={hazard.name in addressHazardData ? true : false}

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -15,13 +15,19 @@ import Share from "./share";
 import { CardContainer } from "./card-container";
 import { KeyElem } from "./key-elem";
 
+type HazardData = {
+  softStory?: any;
+  tsunamiZone?: any;
+  liquefactionZone?: any;
+};
+
 const Report = ({
   searchedAddress,
   addressHazardData,
   isHazardDataLoading,
 }: {
   searchedAddress: string;
-  addressHazardData: object[] | undefined;
+  addressHazardData: HazardData | undefined;
   isHazardDataLoading: boolean;
 }) => {
   return (
@@ -121,7 +127,7 @@ const Report = ({
               key={hazard.id}
               hazard={hazard}
               hazardData={
-                addressHazardData ? addressHazardData[index] : undefined
+                addressHazardData?.[hazard.name as keyof HazardData] ?? undefined
               }
               showData={addressHazardData ? true : false}
               isHazardDataLoading={isHazardDataLoading}

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -18,9 +18,11 @@ import { KeyElem } from "./key-elem";
 const Report = ({
   searchedAddress,
   addressHazardData,
+  isHazardDataLoading,
 }: {
   searchedAddress: string;
-  addressHazardData: object[];
+  addressHazardData: object[] | undefined;
+  isHazardDataLoading: boolean;
 }) => {
   return (
     <Center flexDirection="column">
@@ -118,8 +120,11 @@ const Report = ({
             <CardHazard
               key={hazard.id}
               hazard={hazard}
-              hazardData={addressHazardData[index] ?? undefined}
-              showData={searchedAddress ? true : false}
+              hazardData={
+                addressHazardData ? addressHazardData[index] : undefined
+              }
+              showData={addressHazardData ? true : false}
+              isHazardDataLoading={isHazardDataLoading}
             />
           );
         })}

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -119,6 +119,7 @@ const Report = ({
               key={hazard.id}
               hazard={hazard}
               hazardData={addressHazardData[index] ?? undefined}
+              showData={searchedAddress ? true : false}
             />
           );
         })}

--- a/app/components/report.tsx
+++ b/app/components/report.tsx
@@ -27,7 +27,7 @@ const Report = ({
   isHazardDataLoading,
 }: {
   searchedAddress: string;
-  addressHazardData: HazardData | undefined;
+  addressHazardData: HazardData;
   isHazardDataLoading: boolean;
 }) => {
   return (
@@ -129,7 +129,8 @@ const Report = ({
               hazardData={
                 addressHazardData?.[hazard.name as keyof HazardData] ?? undefined
               }
-              showData={addressHazardData ? true : false}
+              // showData={addressHazardData?.[hazard.name as keyof HazardData] ? true : false}
+              showData={hazard.name in addressHazardData ? true : false}
               isHazardDataLoading={isHazardDataLoading}
             />
           );

--- a/app/components/search-bar.jsx
+++ b/app/components/search-bar.jsx
@@ -75,7 +75,11 @@ const SearchBar = ({
       onCoordDataRetrieve(values);
     } catch (error) {
       console.error("Error while retrieving data: ", error?.message || error);
-      onCoordDataRetrieve({});
+      onCoordDataRetrieve({       
+        softStory: null,
+        tsunami: null,
+        liquefaction: null,
+      });
       toast({
         description: "Could not retrieve hazard data",
         status: "error",

--- a/app/components/search-bar.jsx
+++ b/app/components/search-bar.jsx
@@ -37,6 +37,7 @@ const SearchBar = ({
   onSearchChange,
   onAddressSearch,
   onCoordDataRetrieve,
+  onHazardDataLoading,
 }) => {
   const [inputAddress, setInputAddress] = useState("");
   const debug = useSearchParams().get("debug");
@@ -107,6 +108,7 @@ const SearchBar = ({
   // gets metadata from Mapbox API for given coordinates
   const getHazardData = async (coords = coordinates) => {
     try {
+      onHazardDataLoading(true);
       const isSoftStory = await fetch(
         `${API_ENDPOINTS.isSoftStory}?lon=${coords[0]}&lat=${coords[1]}`
       ).then((response) => response.json());
@@ -119,9 +121,14 @@ const SearchBar = ({
         `${API_ENDPOINTS.isInLiquefactionZone}?lon=${coords[0]}&lat=${coords[1]}`
       ).then((response) => response.json());
 
-      return Promise.all([isSoftStory, isInTsunamiZone, isInLiquefactionZone]);
+      return Promise.all([
+        isSoftStory,
+        isInTsunamiZone,
+        isInLiquefactionZone,
+      ]).then(onHazardDataLoading(false));
     } catch (error) {
       console.error("Error fetching hazard data:", error);
+      onHazardDataLoading(false);
       // TODO: Handle error appropriately, e.g., return a default value or re-throw (for now, we are re-throwing)
       throw error;
     }

--- a/app/components/search-bar.jsx
+++ b/app/components/search-bar.jsx
@@ -13,6 +13,7 @@ import {
   NumberInputStepper,
   NumberIncrementStepper,
   NumberDecrementStepper,
+  useToast,
 } from "@chakra-ui/react";
 import { IoSearchSharp } from "react-icons/io5";
 import { RxCross2 } from "react-icons/rx";
@@ -41,6 +42,7 @@ const SearchBar = ({
   const debug = useSearchParams().get("debug");
   const router = useRouter();
   const searchParams = useSearchParams();
+  const toast = useToast();
 
   const handleClearClick = () => {
     setInputAddress("");
@@ -70,9 +72,21 @@ const SearchBar = ({
     try {
       const values = await getHazardData(coords);
       onCoordDataRetrieve(values);
-    } catch {
-      console.log("could not retrieve hazard data");
+    } catch (error) {
+      console.error("Error while retrieving data: ", error?.message || error);
       onCoordDataRetrieve([]);
+      toast({
+        description: "Could not retrieve hazard data",
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+        position: "top",
+        containerStyle: {
+          backgroundColor: "#b53d37",
+          opacity: 1,
+          borderRadius: "12px",
+        },
+      });
     }
   };
 

--- a/app/components/search-bar.jsx
+++ b/app/components/search-bar.jsx
@@ -75,7 +75,7 @@ const SearchBar = ({
       onCoordDataRetrieve(values);
     } catch (error) {
       console.error("Error while retrieving data: ", error?.message || error);
-      onCoordDataRetrieve({       
+      onCoordDataRetrieve({
         softStory: null,
         tsunami: null,
         liquefaction: null,
@@ -112,22 +112,31 @@ const SearchBar = ({
   // gets metadata from Mapbox API for given coordinates
   const getHazardData = async (coords = coordinates) => {
     onHazardDataLoading(true);
-    const buildUrl = (endpoint) => `${endpoint}?lon=${coords[0]}&lat=${coords[1]}`;
+    const buildUrl = (endpoint) =>
+      `${endpoint}?lon=${coords[0]}&lat=${coords[1]}`;
 
     try {
-      const [softStory, tsunamiZone, liquefactionZone] = await Promise.allSettled([
-        fetch(buildUrl(API_ENDPOINTS.isSoftStory)).then(res => res.json()),
-        fetch(buildUrl(API_ENDPOINTS.isInTsunamiZone)).then(res => res.json()),
-        fetch(buildUrl(API_ENDPOINTS.isInLiquefactionZone)).then(res => res.json())
-      ]);
+      const [softStory, tsunamiZone, liquefactionZone] =
+        await Promise.allSettled([
+          fetch(buildUrl(API_ENDPOINTS.isSoftStory)).then((res) => res.json()),
+          fetch(buildUrl(API_ENDPOINTS.isInTsunamiZone)).then((res) =>
+            res.json()
+          ),
+          fetch(buildUrl(API_ENDPOINTS.isInLiquefactionZone)).then((res) =>
+            res.json()
+          ),
+        ]);
 
       onHazardDataLoading(false);
 
       return {
         softStory: softStory.status === "fulfilled" ? softStory.value : null,
         tsunami: tsunamiZone.status === "fulfilled" ? tsunamiZone.value : null,
-        liquefaction: liquefactionZone.status === "fulfilled" ? liquefactionZone.value : null,
-      }
+        liquefaction:
+          liquefactionZone.status === "fulfilled"
+            ? liquefactionZone.value
+            : null,
+      };
     } catch (error) {
       console.error("Error fetching hazard data:", error);
       onHazardDataLoading(false);


### PR DESCRIPTION
# Description

Improved hazard data fetching resilience and UI feedback with the following changes:
- Failure to make one API call does not block the rest.
- While hazard data is loading, a spinner is shown instead of the status pill.
- If no data is received, a “No data” pill appears.
- On error, a friendly Toast message is displayed using Chakra UI component.

#274 

## Type of changes
- [ ] Bugfix
- [ ] Chore
- [x] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test
- Use Network Throttling in Browser DevTools to see the loading spinner.
- Stop the backend container to simulate a No data response.

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)