### PR TITLE
Limit Autocomplete and Improve Trigger Threshold

### DIFF
--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -27,7 +27,6 @@ const Map: React.FC<MapProps> = ({
   const markerRef = useRef<mapboxgl.Marker>();
 
   useEffect(() => {
-    console.log(softStoryData);
     const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
 
     if (!mapContainerRef.current || !mapboxToken) {

--- a/app/components/search-bar.jsx
+++ b/app/components/search-bar.jsx
@@ -20,15 +20,14 @@ import { RxCross2 } from "react-icons/rx";
 import DynamicAddressAutofill from "./address-autofill";
 import { API_ENDPOINTS } from "../api/endpoints";
 
-// TODO: share bbox options with what's in `map.tsx`
 const options = {
-  bbox: [
-    [-122.6, 37.65], // Southwest coordinates
-    [-122.25, 37.85], // Northeast coordinates
-  ],
   country: "US",
   limit: 10,
-  // proximity: , // TODO: consider passing in current center of map
+  bbox: [
+    [-122.55, 37.69],
+    [-122.35, 37.83],
+  ],
+  proximity: { lng: -122.4194, lat: 37.7749 },
   streets: false,
 };
 


### PR DESCRIPTION
# Description
Mapbox autocomplete options updated to prioritize San Francisco addresses in search results. Additionally, the update resolved the issue with the delayed autocomplete trigger — now suggestions appear as soon as you type three characters.

#299 
#298

## Type of changes
- [ ] Bugfix
- [ ] Chore
- [x] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test
Start typing an address in the search box—results should now show up quicker and highlight San Francisco addresses first.

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)