### PR TITLE
Fix hide illustration on mobile

### DIFF
--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -320,7 +320,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
               </ListItem>
             </List>
           </div>
-          <Box flexShrink={0}>
+          <Box flexShrink={0} display={{ base: "none", lg: "block" }}>
             <Image
               src="/images/earthquake-ready.png"
               alt="about us"


### PR DESCRIPTION
# Description

hide illustration on main page to allow for text to be more readable on mobile

#359 

## Type of changes
- [x] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

Before
<img width="670" alt="before" src="https://github.com/user-attachments/assets/65beb53d-29d9-4300-add1-aab4a56c6a4e" />

After
<img width="670" alt="after" src="https://github.com/user-attachments/assets/fe619d2c-4f28-4785-af2a-fc4ccde8b101" />

Open web site on mobile and note that the illustration no longer appears.

Alternatively, open in desktop browser and shrink width until hitting mobile responsive breakpoint. Note that the illustration no longer appears.

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)