### PR TITLE
fix medium header font and body text color; convert list styles to la…

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -64,7 +64,7 @@ const About = () => {
     >
       <Flex direction="column" alignItems={"flex-start"} gap="48px">
         <Heading headingData={headingData} />
-        <Text textStyle="textBig" color="black">
+        <Text textStyle="textBig">
           Seismologists predict a 72% probability that the Bay Area will
           experience a magnitude 6.7 (or greater) earthquake in the next 30
           years. SafeHome was created to give San Franciscans the knowledge and

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -146,7 +146,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 earthquake-ready
               </Text>
             </Heading>
-            <Text as="p" mt="2" textStyle="textBig" color="black">
+            <Text as="p" mt="2" textStyle="textBig">
               Whether you’re a renter, homeowner, or property manager, these
               resources can help you make confident, informed decisions around
               earthquake safety.
@@ -161,8 +161,8 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
               around, but what do they actually mean?
             </Text>
 
-            <List textStyle="list" mt="2">
-              <ListItem textStyle="listItem">
+            <List textStyle="textMedium" layerStyle="list" mt="2">
+              <ListItem layerStyle="listItem">
                 A{" "}
                 <Text as="span" textStyle="textSemibold">
                   soft story
@@ -171,7 +171,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 level, such as a garage or retail space, below one or more
                 living spaces.
               </ListItem>
-              <ListItem textStyle="listItem">
+              <ListItem layerStyle="listItem">
                 <Text as="span" textStyle="textSemibold">
                   Earthquake retrofitting
                 </Text>{" "}
@@ -179,7 +179,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 an earthquake, such as adding structural reinforcements or
                 upgrading the foundation to better withstand shaking.
               </ListItem>
-              <ListItem textStyle="listItem">
+              <ListItem layerStyle="listItem">
                 San Francisco’s{" "}
                 <Text as="span" textStyle="textSemibold">
                   Mandatory Soft Story Retrofit Ordinance
@@ -202,8 +202,8 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
               earthquakes.
             </Text>
 
-            <List textStyle="list" mt="2">
-              <ListItem textStyle="listItem">
+            <List textStyle="textMedium" layerStyle="list" mt="2">
+              <ListItem layerStyle="listItem">
                 <Link
                   as={NextLink}
                   href="https://www.ready.gov/earthquakes"
@@ -213,7 +213,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 </Link>{" "}
                 in an earthquake.
               </ListItem>
-              <ListItem textStyle="listItem">
+              <ListItem layerStyle="listItem">
                 <Link
                   as={NextLink}
                   href="https://www.ready.gov/kit"
@@ -223,7 +223,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 </Link>{" "}
                 with first aid supplies, batteries, and other essentials.
               </ListItem>
-              <ListItem textStyle="listItem">
+              <ListItem layerStyle="listItem">
                 <Link
                   as={NextLink}
                   href="https://myshake.berkeley.edu/"
@@ -245,8 +245,8 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
               resources can help you get started.
             </Text>
 
-            <List textStyle="list" mt="2">
-              <ListItem textStyle="listItem">
+            <List textStyle="textMedium" layerStyle="list" mt="2">
+              <ListItem layerStyle="listItem">
                 <Link
                   as={NextLink}
                   href="https://www.californiaresidentialmitigationprogram.com/our-seismic-retrofit-programs/the-retrofits/ess-retrofit"
@@ -256,7 +256,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 </Link>{" "}
                 about what’s involved in a seismic retrofit.
               </ListItem>
-              <ListItem textStyle="listItem">
+              <ListItem layerStyle="listItem">
                 <Link
                   as={NextLink}
                   href="https://www.californiaresidentialmitigationprogram.com/resources/find-a-contractor/"
@@ -266,7 +266,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 </Link>{" "}
                 who can perform the right updates to your home.
               </ListItem>
-              <ListItem textStyle="listItem">
+              <ListItem layerStyle="listItem">
                 Check your eligibility for an{" "}
                 <Link
                   as={NextLink}
@@ -297,8 +297,8 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
               or tsunami zone, you may want to look into these additional
               resources.
             </Text>
-            <List textStyle="list" mt="2">
-              <ListItem textStyle="listItem">
+            <List textStyle="textMedium" layerStyle="list" mt="2">
+              <ListItem layerStyle="listItem">
                 <Link
                   as={NextLink}
                   href="https://www.earthquakeauthority.com/california-earthquake-insurance-policies/renters"
@@ -308,7 +308,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 </Link>{" "}
                 to cover your personal belongings.
               </ListItem>
-              <ListItem textStyle="listItem">
+              <ListItem layerStyle="listItem">
                 <Link
                   as={NextLink}
                   href="https://sftu.org/repairs/"

--- a/app/components/base-card.tsx
+++ b/app/components/base-card.tsx
@@ -19,7 +19,7 @@ export const BaseCard = ({
     <Card flex={1} maxW={400} p={{ base: "16px", md: "20px" }}>
       <CardHeader p={0}>
         {typeof title === "string" ? (
-          <Text textStyle="textBig">{title}</Text>
+          <Text textStyle="cardTitle">{title}</Text>
         ) : (
           <>{title}</>
         )}

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -79,12 +79,12 @@ const CardHazard: React.FC<CardHazardProps> = ({
         <PopoverTrigger>
           <VStack cursor={"pointer"} alignItems={"flex-start"} h={"100%"}>
             <CardHeader p={0}>
-              <Text textStyle="textBig" fontWeight={"700"}>
+              <Text textStyle="cardTitle" fontWeight={"700"}>
                 {title}
               </Text>
             </CardHeader>
             <CardBody p={0} mb={"14px"}>
-              <Text>{description}</Text>
+              <Text textStyle="textMedium">{description}</Text>
             </CardBody>
             <CardFooter p={0} width={"100%"}>
               <HStack justifyContent="space-between" width="100%">

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -30,7 +30,7 @@ const customTheme = extendTheme({
       fontSize: ["2xl", "2xl", "3xl", "3xl", "3xl", "3xl"],
       fontWeight: "500",
       color: "blue",
-      fontFamily: "body",
+      fontFamily: "heading",
     },
     headerSmall: {
       fontSize: ["lg", "lg", "lg", "lg", "xl", "xl"],

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -38,10 +38,16 @@ const customTheme = extendTheme({
       color: "white",
       fontFamily: "body",
     },
-    textBig: {
+    cardTitle: {
       fontSize: "xl",
       fontWeight: "normal",
       color: "blue",
+      fontFamily: "body",
+    },
+    textBig: {
+      fontSize: "xl",
+      fontWeight: "normal",
+      color: "grey.900",
       fontFamily: "body",
     },
     textMedium: {
@@ -59,6 +65,8 @@ const customTheme = extendTheme({
     textSemibold: {
       fontWeight: "600",
     },
+  },
+  layerStyles: {
     list: {
       listStyleType: "disc",
       paddingLeft: "6",


### PR DESCRIPTION
…yer styles

# Description

fixes:
- medium header font family (should be `Manrope`, not `Inter`) on main page, about page, ToS page
- body text color (ought to be `grey/900`)

Also changes list styles from Chakra text styles to layer styles

#357

## Type of changes
- [x] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

Please check latest Vercel preview deployment URL (at bottom of page) against Figma.

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)