### PR TITLE
add beta label next to SafeHome logo

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -50,15 +50,18 @@ const Header = () => {
             window.location.href = "/";
           }}
         >
-          <HStack align="baseline">
-            <Image
-              src="/images/SFSafeHome-fulllogo.svg"
-              alt="SafeHome logo"
-              role="img" // needed for VoiceOver bug: https://bugs.webkit.org/show_bug.cgi?id=216364
-              h="28px"
-              w="142px"
-            />
-            <VisuallyHidden>SafeHome</VisuallyHidden>
+          <HStack align="start" gap="1">
+            <HStack align="baseline">
+              <Image
+                src="/images/SFSafeHome-fulllogo.svg"
+                alt="SafeHome logo"
+                role="img" // needed for VoiceOver bug: https://bugs.webkit.org/show_bug.cgi?id=216364
+                h="28px"
+                w="142px"
+              />
+              <VisuallyHidden>SafeHome</VisuallyHidden>
+            </HStack>
+            <Text textStyle="textPrerelease">Beta</Text>
           </HStack>
         </Link>
         {isHome && <Box ref={portalRef} id="searchbar-portal" />}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -59,6 +59,13 @@ const customTheme = extendTheme({
     textSemibold: {
       fontWeight: "600",
     },
+    textPrerelease: {
+      color: "#ccc",
+      fontSize: "12px",
+      lineHeight: "12px",
+      fontWeight: "bold",
+      textTransform: "uppercase",
+    },
   },
   layerStyles: {
     list: {


### PR DESCRIPTION
# Description

add a quick "BETA" label next to SafeHome logo to signal prerelease status

## Type of changes
- [ ] Bugfix
- [x] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

Check to see if BETA label is showing next to logo.

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)