### PR TITLE
Increased healthcheck intervals

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,8 @@ services:
       - nextjs_cache:/app/.next
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:3000 || exit 1" ]
-      interval: 10s
+      start_interval: 10s
+      interval: 500s
       timeout: 5s
       retries: 3
       start_period: 60s
@@ -41,7 +42,8 @@ services:
     command: bash /startup.sh
     healthcheck:
       test: [ "CMD-SHELL", "curl -f http://localhost:8000/api/health || exit 1" ]
-      interval: 10s
+      start_interval: 10s
+      interval: 500s
       timeout: 5s
       retries: 5
       start_period: 30s
@@ -60,7 +62,8 @@ services:
       - 5433:5432
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
-      interval: 10s
+      start_interval: 10s
+      interval: 500s
       timeout: 5s
       retries: 5
       start_period: 30s
@@ -81,7 +84,8 @@ services:
       - 5432:5432
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
-      interval: 10s
+      start_interval: 10s
+      interval: 500s
       timeout: 5s
       retries: 5
       start_period: 30s


### PR DESCRIPTION
# Description

The healthchecks will now be much further apart (500s) after Docker has verified that they are healthy.

#341 

## Type of changes
- [ ] Bugfix
- [x] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

Start the container and time the healthchecks.  The first ones are 10 seconds apart, but the ones after are 500s apart.

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)