### PR TITLE
Close Hazard card when clicking a second time

### DIFF
--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -92,9 +92,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
               </Text>
             </CardHeader>
             <CardBody p={0} mb={"14px"}>
-              <Text textStyle="textMedium" alignSelf="flex-start">
-                {description}
-              </Text>
+              <Text textStyle="textMedium">{description}</Text>
             </CardBody>
             <CardFooter p={0} width={"100%"}>
               <HStack justifyContent="space-between" width="100%">

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -8,11 +8,7 @@ import {
   CardBody,
   Card,
   CardHeader,
-  useDisclosure,
   Spinner,
-} from "@chakra-ui/react";
-import Pill from "./pill";
-import {
   Popover,
   PopoverTrigger,
   PopoverContent,
@@ -20,6 +16,7 @@ import {
   PopoverArrow,
   PopoverCloseButton,
 } from "@chakra-ui/react";
+import Pill from "./pill";
 
 interface CardHazardProps {
   hazard: {
@@ -77,14 +74,27 @@ const CardHazard: React.FC<CardHazardProps> = ({
         aria-label={`${hazard.title} information`}
       >
         <PopoverTrigger>
-          <VStack cursor={"pointer"} alignItems={"flex-start"} h={"100%"}>
-            <CardHeader p={0}>
+          <Button
+            variant="unstyled"
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "flex-start",
+              height: "100%",
+              textWrap: "wrap",
+              textAlign: "start",
+              width: "100%",
+            }}
+          >
+            <CardHeader p={0} marginBottom={"0.5em"}>
               <Text textStyle="cardTitle" fontWeight={"700"}>
                 {title}
               </Text>
             </CardHeader>
             <CardBody p={0} mb={"14px"}>
-              <Text textStyle="textMedium">{description}</Text>
+              <Text textStyle="textMedium" alignSelf="flex-start">
+                {description}
+              </Text>
             </CardBody>
             <CardFooter p={0} width={"100%"}>
               <HStack justifyContent="space-between" width="100%">
@@ -94,7 +104,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
                 {hazardPill}
               </HStack>
             </CardFooter>
-          </VStack>
+          </Button>
         </PopoverTrigger>
         <PopoverContent mt={5} width={"348px"}>
           <PopoverArrow />

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -76,15 +76,13 @@ const CardHazard: React.FC<CardHazardProps> = ({
         <PopoverTrigger>
           <Button
             variant="unstyled"
-            sx={{
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "flex-start",
-              height: "100%",
-              textWrap: "wrap",
-              textAlign: "start",
-              width: "100%",
-            }}
+            display="flex"
+            flexDirection="column"
+            alignItems="flex-start"
+            height="100%"
+            width="100%"
+            whiteSpace="normal"
+            textAlign="start"
           >
             <CardHeader p={0} marginBottom={"0.5em"}>
               <Text textStyle="cardTitle" fontWeight={"700"}>


### PR DESCRIPTION
# Description

Fixes the CardHazard component so that it closes the "More Info" panel when clicking the CardHazard for a second time. It seems to be necessary for the PopoverTrigger component to render a button in order to get the expected default behavior

Closes https://github.com/sfbrigade/datasci-earthquake/issues/401

## Type of changes
- [x] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

run the app and check that the desired behavior is shown

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)