### PR TITLE
Add HazardData type.

### DIFF
--- a/app/components/home-header.tsx
+++ b/app/components/home-header.tsx
@@ -11,14 +11,19 @@ import Share from "./share";
 import ShareSkeleton from "./share-skeleton";
 import { AnimatePresence, motion } from "framer-motion";
 import SearchBarSkeleton from "./search-bar-skeleton";
-import { CoordinateData } from "../types/index";
+
+type HazardData = {
+  liquefaction: { exists: boolean; last_updated: string | null } | null;
+  softStory: { exists: boolean; last_updated: string | null } | null;
+  tsunami: { exists: boolean; last_updated: string | null } | null;
+};
 
 interface HomeHeaderProps {
   coordinates: number[];
   searchedAddress: string;
   onSearchChange: (coords: number[]) => void;
   onAddressSearch: (address: string) => void;
-  onCoordDataRetrieve: (data: CoordinateData) => void;
+  onCoordDataRetrieve: (data: HazardData) => void;
   onHazardDataLoading: (isLoading: boolean) => void;
 }
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,5 +1,0 @@
-export type CoordinateData = {
-  liquefaction: { exists: boolean; last_updated: string | null } | null;
-  softStory: { exists: boolean; last_updated: string | null } | null;
-  tsunami: { exists: boolean; last_updated: string | null } | null;
-};


### PR DESCRIPTION
# Description

- Closes https://github.com/sfbrigade/datasci-earthquake/issues/439

1.  Added a new folder and file for adding TS types
2. Adding a more specific type for the data prop in `onCoordDataRetrieve`. I logged the shape of the values used in the data object(screenshot below). Looks like `exists` will always be returned as a boolean and `last_updated` can be null or a string value.

Note: this is my first PR in the project so definitely possible I missed something.

<img width="1710" alt="Screenshot 2025-06-30 at 12 28 38 AM" src="https://github.com/user-attachments/assets/2db11a28-c544-4e4c-9429-8cfe8a338833" />

## Type of changes
- [ ] Bugfix
- [x] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

_testing description here: i.e. run app, go to x page, see that it does y_

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)