### PR TITLE
fix and tweak hazard card look and feel

### DIFF
--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -9,7 +9,6 @@ import {
   Spinner,
   Popover,
   Portal,
-  Button,
 } from "@chakra-ui/react";
 import posthog from "posthog-js";
 import Pill from "./pill";
@@ -34,8 +33,6 @@ const CardHazard: React.FC<CardHazardProps> = ({
   showData,
   isHazardDataLoading,
 }) => {
-  // const posthog = usePostHog();
-
   const { title, name, description } = hazard;
   const { exists, last_updated: date } = hazardData || {};
 
@@ -48,13 +45,11 @@ const CardHazard: React.FC<CardHazardProps> = ({
   );
 
   const buildHazardCardInfo = () => {
-    return (
-      <VStack gap={5} p={5}>
-        {hazard.info.map((infoItem, index) => (
-          <Text key={index}>{infoItem}</Text>
-        ))}
-      </VStack>
-    );
+    return hazard.info.map((infoItem, index) => (
+      <Text as="p" mt="4" key={index}>
+        {infoItem}
+      </Text>
+    ));
   };
 
   return (
@@ -62,15 +57,16 @@ const CardHazard: React.FC<CardHazardProps> = ({
       <Popover.Root
         positioning={{
           placement: "bottom",
-          offset: { crossAxis: 0, mainAxis: 0 },
+          flip: false,
+          offset: { crossAxis: 0, mainAxis: 24 },
         }}
         closeOnEscape={true}
         closeOnInteractOutside={true}
         aria-label={`${hazard.title} information`}
       >
-        <Popover.Trigger css={{ backgroundColor: "white" }}>
-          <VStack cursor={"pointer"} alignItems={"flex-start"} h={"100%"}>
-            <Card.Header p={0} marginBottom={"0.5em"}>
+        <Popover.Trigger h="full">
+          <VStack cursor={"pointer"} alignItems={"flex-start"} h="full">
+            <Card.Header p={0} marginBottom={"0.5em"} textAlign="left">
               <Text
                 textStyle="cardTitle"
                 layerStyle="headerAlt"
@@ -79,7 +75,6 @@ const CardHazard: React.FC<CardHazardProps> = ({
                 {title}
               </Text>
             </Card.Header>
-            {/* TODO: shouldn't need text align left (temporary fix) ... something else is causing the text to be centered; looking into it further, there's a text align center somewhere, possibly as part of an enclosing button element, so we may need this after all */}
             <Card.Body textAlign="left" p={0} mb={"14px"}>
               <Text textStyle="textMedium" layerStyle="text">
                 {description}
@@ -97,34 +92,24 @@ const CardHazard: React.FC<CardHazardProps> = ({
         </Popover.Trigger>
         <Portal>
           <Popover.Positioner>
-            {/* TODO FIXME: can below line be styled with mt={5} width={"348px"} somehow still? how? should it go on `<Popover.Body>`? or elsewhere? */}
-            <Popover.Content>
-              {/* TODO FIXME: can below line replace the <PopoverCloseButton />? */}
+            <Popover.Content maxHeight="unset">
               <Popover.CloseTrigger
-                display={"flex"}
-                justifyContent="end"
-                paddingRight="3"
-                paddingTop="3"
+                cursor="pointer"
+                position="absolute"
+                top="2"
+                right="2"
               >
-                <RxCross2
-                  color="grey.900"
-                  fontSize="1.1em"
-                  size="20"
-                  data-testid="clear-icon"
-                />
+                <RxCross2 color="grey.900" size="20" data-testid="clear-icon" />
               </Popover.CloseTrigger>
               <Popover.Arrow>
                 <Popover.ArrowTip />
               </Popover.Arrow>
-              <Popover.Body
-                css={{ backgroundColor: "white", borderRadius: "6px" }}
-              >
+              <Popover.Body>
                 {buildHazardCardInfo()}
                 <Link
                   display={"inline-block"}
-                  pb={3}
-                  pl={5}
                   href={hazard.link.url}
+                  mt="4"
                   target="_blank"
                   textDecoration="underline"
                   onClick={() =>


### PR DESCRIPTION
# Description

fixes card hazard info popover regression. had to turn on `flipped: false` and add a close button.

## Original (Chakra v2)
<img width="1064" height="727" alt="Screenshot 2025-07-17 at 2 24 18 AM" src="https://github.com/user-attachments/assets/43377774-1f2b-47b6-a634-0e1bedf02afa" />

## Before - buggy (Chakra v3)
<img width="1064" height="727" alt="Screenshot 2025-07-17 at 2 24 24 AM" src="https://github.com/user-attachments/assets/9c7b05d3-a86b-4319-a475-9876b94495ad" />

## After - fixed (Chakra v3)
<img width="1064" height="727" alt="Screenshot 2025-07-17 at 2 24 27 AM" src="https://github.com/user-attachments/assets/b0d4bae8-2c60-44a9-b584-cb292f5ef036" />

## Type of changes
- [x] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

Compare to both https://develop.safehome.report and https://safehome.report

## Clean commits
- [ ] I plan to Squash and Merge
- [x] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)