### PR TITLE
Add useHazardDataFetcher hook and refactored search-bar component to use hook

### DIFF
--- a/app/components/__tests__/hooks/useHazardDataFetcher.test.tsx
+++ b/app/components/__tests__/hooks/useHazardDataFetcher.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook, act } from "@testing-library/react";
-import { useHazardDataFetcher } from "../../hooks/useHazardDataFetcher";
+import { useHazardDataFetcher } from "../../../hooks/useHazardDataFetcher";
 import { toaster } from "@/components/ui/toaster";
 
 const fetchMock = jest.fn();

--- a/app/components/__tests__/useHazardDataFetcher.test.tsx
+++ b/app/components/__tests__/useHazardDataFetcher.test.tsx
@@ -1,0 +1,115 @@
+import { renderHook, act } from "@testing-library/react";
+import { useHazardDataFetcher } from "../../hooks/useHazardDataFetcher";
+import { toaster } from "@/components/ui/toaster";
+
+const fetchMock = jest.fn();
+global.fetch = fetchMock;  
+
+// mock for a successful fetch response
+const mockSuccessResponse = (data: {exists: boolean; last_updated: string | null}) =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(data),
+  });
+
+// mock for a failed fetch response
+const mockFailedResponse = () =>
+  Promise.resolve({
+    ok: false,
+    status: 500,
+    statusText: 'Internal Server Error',
+    text: () => Promise.resolve('Internal Server Error'),
+  });
+
+// Mock the toaster component
+jest.mock('@/components/ui/toaster', () => ({
+  toaster: {
+    create: jest.fn(),
+    isVisible: jest.fn(() => false),
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("should fetch all hazard data successfully", async () => {
+  // Setup
+  fetchMock.mockImplementation((url) => {
+    if (url.includes('soft-story')) {
+      return mockSuccessResponse({ exists: false, last_updated: null });
+    }
+    if (url.includes('tsunami')) {
+      return mockSuccessResponse({ exists: false, last_updated: null });
+    }
+    if (url.includes('liquefaction')) {
+      return mockSuccessResponse({ exists: true, last_updated: "2025-08-05T17:03:03.555976Z" });
+    }
+    return mockSuccessResponse({ exists: false, last_updated: null });
+  });
+
+  const onSearchComplete = jest.fn();
+  const onHazardDataLoading = jest.fn();
+
+  const { result } = renderHook(() =>
+    useHazardDataFetcher({ onSearchComplete, onHazardDataLoading })
+  );
+
+  // Act to run the hook's async function
+  let returnedValue;
+  await act(async () => {
+    returnedValue = await result.current.fetchHazardData([12, 34]);
+  });
+
+  // Assertions
+  expect(onHazardDataLoading).toHaveBeenNthCalledWith(1, true);
+  expect(onSearchComplete).toHaveBeenCalledWith(true);
+  expect(toaster.create).not.toHaveBeenCalled();
+  expect(onHazardDataLoading).toHaveBeenNthCalledWith(2, false);
+  expect(fetchMock).toHaveBeenCalledTimes(3);
+
+  expect(returnedValue).toEqual({
+    softStory: { exists: false, last_updated: null },
+    tsunami: { exists: false, last_updated: null },
+    liquefaction: { exists: true, last_updated: "2025-08-05T17:03:03.555976Z" },
+  });
+});
+
+test("should show a warning toast when one API call fails", async () => {
+  // Setup
+  // Mock fetch to succeed for first two calls and fail for the third(Liquefaction)
+  fetchMock
+    .mockResolvedValueOnce(mockSuccessResponse({ exists: false, last_updated: null }))
+    .mockResolvedValueOnce(mockSuccessResponse({ exists: false, last_updated: null }))
+    .mockResolvedValueOnce(mockFailedResponse());
+
+  const onSearchComplete = jest.fn();
+  const onHazardDataLoading = jest.fn();
+
+  const { result } = renderHook(() =>
+    useHazardDataFetcher({ onSearchComplete, onHazardDataLoading })
+  );
+
+  // Act to run the hook's async function
+  let returnedValue;
+  await act(async () => {
+    returnedValue = await result.current.fetchHazardData([12, 34]);
+  });
+
+  // Assertions
+  expect(onSearchComplete).toHaveBeenCalledWith(true);
+  expect(toaster.create).toHaveBeenCalledWith(
+    expect.objectContaining({
+      title: "Hazard data warning",
+      description: "Failed to fetch: Liquefaction",
+    })
+  );
+  expect(onHazardDataLoading).toHaveBeenCalledTimes(2);
+  expect(fetchMock).toHaveBeenCalledTimes(3);
+
+  expect(returnedValue).toEqual({
+    softStory: { exists: false, last_updated: null },
+    tsunami: { exists: false, last_updated: null },
+    liquefaction: null,
+  });
+});

--- a/app/components/__tests__/useHazardDataFetcher.test.tsx
+++ b/app/components/__tests__/useHazardDataFetcher.test.tsx
@@ -46,9 +46,9 @@ test("should fetch all hazard data successfully", async () => {
       return mockSuccessResponse({ exists: false, last_updated: null });
     }
     if (url.includes("liquefaction")) {
-      return mockSuccessResponse({ 
+      return mockSuccessResponse({
         exists: true,
-        last_updated: "2025-08-05T17:03:03.555976Z"
+        last_updated: "2025-08-05T17:03:03.555976Z",
       });
     }
     return mockSuccessResponse({ exists: false, last_updated: null });

--- a/app/components/__tests__/useHazardDataFetcher.test.tsx
+++ b/app/components/__tests__/useHazardDataFetcher.test.tsx
@@ -3,10 +3,13 @@ import { useHazardDataFetcher } from "../../hooks/useHazardDataFetcher";
 import { toaster } from "@/components/ui/toaster";
 
 const fetchMock = jest.fn();
-global.fetch = fetchMock;  
+global.fetch = fetchMock;
 
 // mock for a successful fetch response
-const mockSuccessResponse = (data: {exists: boolean; last_updated: string | null}) =>
+const mockSuccessResponse = (data: {
+  exists: boolean;
+  last_updated: string | null;
+}) =>
   Promise.resolve({
     ok: true,
     json: () => Promise.resolve(data),
@@ -17,12 +20,12 @@ const mockFailedResponse = () =>
   Promise.resolve({
     ok: false,
     status: 500,
-    statusText: 'Internal Server Error',
-    text: () => Promise.resolve('Internal Server Error'),
+    statusText: "Internal Server Error",
+    text: () => Promise.resolve("Internal Server Error"),
   });
 
 // Mock the toaster component
-jest.mock('@/components/ui/toaster', () => ({
+jest.mock("@/components/ui/toaster", () => ({
   toaster: {
     create: jest.fn(),
     isVisible: jest.fn(() => false),
@@ -36,14 +39,17 @@ beforeEach(() => {
 test("should fetch all hazard data successfully", async () => {
   // Setup
   fetchMock.mockImplementation((url) => {
-    if (url.includes('soft-story')) {
+    if (url.includes("soft-story")) {
       return mockSuccessResponse({ exists: false, last_updated: null });
     }
-    if (url.includes('tsunami')) {
+    if (url.includes("tsunami")) {
       return mockSuccessResponse({ exists: false, last_updated: null });
     }
-    if (url.includes('liquefaction')) {
-      return mockSuccessResponse({ exists: true, last_updated: "2025-08-05T17:03:03.555976Z" });
+    if (url.includes("liquefaction")) {
+      return mockSuccessResponse({ 
+        exists: true,
+        last_updated: "2025-08-05T17:03:03.555976Z"
+      });
     }
     return mockSuccessResponse({ exists: false, last_updated: null });
   });
@@ -79,8 +85,12 @@ test("should show a warning toast when one API call fails", async () => {
   // Setup
   // Mock fetch to succeed for first two calls and fail for the third(Liquefaction)
   fetchMock
-    .mockResolvedValueOnce(mockSuccessResponse({ exists: false, last_updated: null }))
-    .mockResolvedValueOnce(mockSuccessResponse({ exists: false, last_updated: null }))
+    .mockResolvedValueOnce(
+      mockSuccessResponse({ exists: false, last_updated: null })
+    )
+    .mockResolvedValueOnce(
+      mockSuccessResponse({ exists: false, last_updated: null })
+    )
     .mockResolvedValueOnce(mockFailedResponse());
 
   const onSearchComplete = jest.fn();

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -51,7 +51,6 @@ const SearchBar = ({
   const [inputAddress, setInputAddress] = useState("");
   const router = useRouter();
   const searchParams = useSearchParams();
-  const toastIdFailedHazardData = "failed-hazard-data";
 
   const { fetchHazardData } = useHazardDataFetcher({
     onSearchComplete,

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -18,7 +18,7 @@ import DynamicAddressAutofill, {
   AddressAutofillRetrieveResponse,
 } from "./address-autofill";
 import type { HazardData } from "./home-header";
-import { API_ENDPOINTS } from "../api/endpoints";
+import { useHazardDataFetcher } from '../hooks/useHazardDataFetcher';
 
 const autofillOptions: AddressAutofillOptions = {
   country: "US",
@@ -27,17 +27,6 @@ const autofillOptions: AddressAutofillOptions = {
   proximity: { lng: -122.4194, lat: 37.7749 },
   streets: false,
   language: "en",
-};
-
-const safeJsonFetch = async (url: string) => {
-  const res = await fetch(url);
-  if (!res.ok) {
-    const text = await res.text(); // capture any error response
-    throw new Error(
-      `HTTP ${res.status} - ${res.statusText} | ${text} | URL: ${url}`
-    );
-  }
-  return res.json();
 };
 
 // NOTE: UI changes to this page ought to be reflected in its suspense skeleton `search-bar-skeleton.tsx` and vice versa
@@ -63,6 +52,13 @@ const SearchBar = ({
   const router = useRouter();
   const searchParams = useSearchParams();
   const toastIdFailedHazardData = "failed-hazard-data";
+
+  const {
+    fetchHazardData,
+  } = useHazardDataFetcher({
+    onSearchComplete: onSearchComplete,
+    onHazardDataLoading: onHazardDataLoading,
+  });
 
   const handleClearClick = () => {
     setInputAddress("");
@@ -90,7 +86,7 @@ const SearchBar = ({
 
   const updateHazardData = async (coords: number[]) => {
     try {
-      const values = await getHazardData(coords);
+      const values = await fetchHazardData(coords);
       onCoordDataRetrieve(values);
     } catch (error) {
       console.error(
@@ -123,60 +119,6 @@ const SearchBar = ({
     event.preventDefault();
 
     // TODO: capture and update address as described above
-  };
-
-  // gets metadata from Mapbox API for given coordinates
-  const getHazardData = async (coords = coordinates) => {
-    onHazardDataLoading(true);
-    const buildUrl = (endpoint: string) =>
-      `${endpoint}?lon=${coords[0]}&lat=${coords[1]}`;
-
-    try {
-      const [softStory, tsunamiZone, liquefactionZone] =
-        await Promise.allSettled([
-          safeJsonFetch(buildUrl(API_ENDPOINTS.isSoftStory)),
-          safeJsonFetch(buildUrl(API_ENDPOINTS.isInTsunamiZone)),
-          safeJsonFetch(buildUrl(API_ENDPOINTS.isInLiquefactionZone)),
-        ]);
-
-      onHazardDataLoading(false);
-      onSearchComplete(true);
-
-      const failed = [
-        { name: "Soft Story", result: softStory },
-        { name: "Tsunami", result: tsunamiZone },
-        { name: "Liquefaction", result: liquefactionZone },
-      ].filter(({ result }) => result.status === "rejected");
-
-      if (failed.length > 0) {
-        if (!toaster.isVisible(toastIdFailedHazardData)) {
-          toaster.create({
-            id: toastIdFailedHazardData,
-            title: "Hazard data warning",
-            description: `Failed to fetch: ${failed
-              .map((f) => f.name)
-              .join(", ")}`,
-            type: "warning",
-            duration: 5000,
-            closable: true,
-          });
-        }
-      }
-
-      return {
-        softStory: softStory.status === "fulfilled" ? softStory.value : null,
-        tsunami: tsunamiZone.status === "fulfilled" ? tsunamiZone.value : null,
-        liquefaction:
-          liquefactionZone.status === "fulfilled"
-            ? liquefactionZone.value
-            : null,
-      };
-    } catch (error) {
-      console.error("Error fetching hazard data:", error);
-      throw error;
-    } finally {
-      onHazardDataLoading(false);
-    }
   };
 
   // temporary memoization fix for updating the address in the search bar.

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -123,7 +123,10 @@ const SearchBar = ({
   // TODO: refactor how we are caching our calls
   const memoizedOnSearchChange = useCallback(onSearchChange, []);
   const memoizedOnAddressSearch = useCallback(onAddressSearch, []);
-  const memoizedUpdateHazardData = useCallback(updateHazardData, [fetchHazardData, onCoordDataRetrieve]);
+  const memoizedUpdateHazardData = useCallback(updateHazardData, [
+    fetchHazardData, 
+    onCoordDataRetrieve
+  ]);
 
   useEffect(() => {
     const address = searchParams.get("address");

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -18,7 +18,7 @@ import DynamicAddressAutofill, {
   AddressAutofillRetrieveResponse,
 } from "./address-autofill";
 import type { HazardData } from "./home-header";
-import { useHazardDataFetcher } from '../hooks/useHazardDataFetcher';
+import { useHazardDataFetcher } from "../hooks/useHazardDataFetcher";
 
 const autofillOptions: AddressAutofillOptions = {
   country: "US",
@@ -53,11 +53,9 @@ const SearchBar = ({
   const searchParams = useSearchParams();
   const toastIdFailedHazardData = "failed-hazard-data";
 
-  const {
-    fetchHazardData,
-  } = useHazardDataFetcher({
-    onSearchComplete: onSearchComplete,
-    onHazardDataLoading: onHazardDataLoading,
+  const { fetchHazardData } = useHazardDataFetcher({
+    onSearchComplete,
+    onHazardDataLoading,
   });
 
   const handleClearClick = () => {
@@ -125,7 +123,7 @@ const SearchBar = ({
   // TODO: refactor how we are caching our calls
   const memoizedOnSearchChange = useCallback(onSearchChange, []);
   const memoizedOnAddressSearch = useCallback(onAddressSearch, []);
-  const memoizedUpdateHazardData = useCallback(updateHazardData, []);
+  const memoizedUpdateHazardData = useCallback(updateHazardData, [fetchHazardData, onCoordDataRetrieve]);
 
   useEffect(() => {
     const address = searchParams.get("address");

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -124,8 +124,8 @@ const SearchBar = ({
   const memoizedOnSearchChange = useCallback(onSearchChange, []);
   const memoizedOnAddressSearch = useCallback(onAddressSearch, []);
   const memoizedUpdateHazardData = useCallback(updateHazardData, [
-    fetchHazardData, 
-    onCoordDataRetrieve
+    fetchHazardData,
+    onCoordDataRetrieve,
   ]);
 
   useEffect(() => {

--- a/app/hooks/useHazardDataFetcher.ts
+++ b/app/hooks/useHazardDataFetcher.ts
@@ -13,12 +13,6 @@ const safeJsonFetch = async (url: string) => {
   return res.json();
 };
 
-interface HazardData {
-  liquefaction: { exists: boolean; last_updated: string | null } | null;
-  softStory: { exists: boolean; last_updated: string | null } | null;
-  tsunami: { exists: boolean; last_updated: string | null } | null;
-}
-
 interface UseHazardDataFetcherProps {
   onSearchComplete: (success: boolean) => void;
   onHazardDataLoading: (loading: boolean) => void;

--- a/app/hooks/useHazardDataFetcher.ts
+++ b/app/hooks/useHazardDataFetcher.ts
@@ -71,7 +71,8 @@ export function useHazardDataFetcher({
 
         return {
           softStory: softStory.status === "fulfilled" ? softStory.value : null,
-          tsunami: tsunamiZone.status === "fulfilled" ? tsunamiZone.value : null,
+          tsunami:
+            tsunamiZone.status === "fulfilled" ? tsunamiZone.value : null,
           liquefaction:
             liquefactionZone.status === "fulfilled"
               ? liquefactionZone.value

--- a/app/hooks/useHazardDataFetcher.ts
+++ b/app/hooks/useHazardDataFetcher.ts
@@ -71,10 +71,7 @@ export function useHazardDataFetcher({
 
         return {
           softStory: softStory.status === "fulfilled" ? softStory.value : null,
-          tsunami: 
-            tsunamiZone.status === "fulfilled" 
-            ? tsunamiZone.value 
-            : null,
+          tsunami: tsunamiZone.status === "fulfilled" ? tsunamiZone.value : null,
           liquefaction:
             liquefactionZone.status === "fulfilled"
               ? liquefactionZone.value

--- a/app/hooks/useHazardDataFetcher.ts
+++ b/app/hooks/useHazardDataFetcher.ts
@@ -1,0 +1,102 @@
+import { useCallback } from 'react';
+import { toaster } from "@/components/ui/toaster";
+import { API_ENDPOINTS } from "../api/endpoints";
+
+const safeJsonFetch = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    const text = await res.text(); // capture any error response
+    throw new Error(
+      `HTTP ${res.status} - ${res.statusText} | ${text} | URL: ${url}`
+    );
+  }
+  return res.json();
+};
+
+interface HazardData {
+  liquefaction: { exists: boolean; last_updated: string | null } | null;
+  softStory: { exists: boolean; last_updated: string | null } | null;
+  tsunami: { exists: boolean; last_updated: string | null } | null;
+}
+
+interface UseHazardDataFetcherProps {
+  onSearchComplete: (success: boolean) => void;
+  onHazardDataLoading: (loading: boolean) => void;
+}
+
+export function useHazardDataFetcher({
+  onSearchComplete,
+  onHazardDataLoading,
+}: UseHazardDataFetcherProps) {
+  console.log("useHazardDataFetcher");
+  const toastIdFailedHazardData = "failed-hazard-data";
+
+  // gets metadata from Mapbox API for given coordinates
+  const getHazardData = useCallback(
+    async (coords: number[]) => {
+      onHazardDataLoading(true);
+
+      const buildUrl = (endpoint: string) =>
+      `${endpoint}?lon=${coords[0]}&lat=${coords[1]}`;
+
+      try {
+        const [softStory, tsunamiZone, liquefactionZone] =
+          await Promise.allSettled([
+            safeJsonFetch(buildUrl(API_ENDPOINTS.isSoftStory)),
+            safeJsonFetch(buildUrl(API_ENDPOINTS.isInTsunamiZone)),
+            safeJsonFetch(buildUrl(API_ENDPOINTS.isInLiquefactionZone)),
+          ]);
+
+        onHazardDataLoading(false);
+        onSearchComplete(true);
+
+        const failed = [
+          { name: "Soft Story", result: softStory },
+          { name: "Tsunami", result: tsunamiZone },
+          { name: "Liquefaction", result: liquefactionZone },
+        ].filter(({ result }) => result.status === "rejected");
+
+        if (failed.length > 0) {
+          if (!toaster.isVisible(toastIdFailedHazardData)) {
+            toaster.create({
+              id: toastIdFailedHazardData,
+              title: "Hazard data warning",
+              description: `Failed to fetch: ${failed
+                .map((f) => f.name)
+                .join(", ")}`,
+              type: "warning",
+              duration: 5000,
+              closable: true,
+            });
+          }
+        }
+
+        return {
+          softStory: softStory.status === "fulfilled" ? softStory.value : null,
+          tsunami: tsunamiZone.status === "fulfilled" ? tsunamiZone.value : null,
+          liquefaction:
+            liquefactionZone.status === "fulfilled"
+              ? liquefactionZone.value
+              : null,
+        };
+      } catch (error) {
+        console.error("Error fetching hazard data:", error);
+        throw error;
+      } finally {
+        onHazardDataLoading(false);
+      }
+    },
+    [onHazardDataLoading, onSearchComplete, toaster, toastIdFailedHazardData]
+  );
+
+  const fetchHazardData = useCallback(
+    async (coords: number[]) => {
+      return getHazardData(coords);
+    },
+    [getHazardData]
+  );
+
+  return {
+    fetchHazardData,
+  }
+}

--- a/app/hooks/useHazardDataFetcher.ts
+++ b/app/hooks/useHazardDataFetcher.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback } from "react";
 import { toaster } from "@/components/ui/toaster";
 import { API_ENDPOINTS } from "../api/endpoints";
 
@@ -28,16 +28,15 @@ export function useHazardDataFetcher({
   onSearchComplete,
   onHazardDataLoading,
 }: UseHazardDataFetcherProps) {
-  console.log("useHazardDataFetcher");
   const toastIdFailedHazardData = "failed-hazard-data";
 
   // gets metadata from Mapbox API for given coordinates
-  const getHazardData = useCallback(
+  const fetchHazardData = useCallback(
     async (coords: number[]) => {
       onHazardDataLoading(true);
 
       const buildUrl = (endpoint: string) =>
-      `${endpoint}?lon=${coords[0]}&lat=${coords[1]}`;
+        `${endpoint}?lon=${coords[0]}&lat=${coords[1]}`;
 
       try {
         const [softStory, tsunamiZone, liquefactionZone] =
@@ -47,7 +46,6 @@ export function useHazardDataFetcher({
             safeJsonFetch(buildUrl(API_ENDPOINTS.isInLiquefactionZone)),
           ]);
 
-        onHazardDataLoading(false);
         onSearchComplete(true);
 
         const failed = [
@@ -73,7 +71,10 @@ export function useHazardDataFetcher({
 
         return {
           softStory: softStory.status === "fulfilled" ? softStory.value : null,
-          tsunami: tsunamiZone.status === "fulfilled" ? tsunamiZone.value : null,
+          tsunami: 
+            tsunamiZone.status === "fulfilled" 
+            ? tsunamiZone.value 
+            : null,
           liquefaction:
             liquefactionZone.status === "fulfilled"
               ? liquefactionZone.value
@@ -86,17 +87,10 @@ export function useHazardDataFetcher({
         onHazardDataLoading(false);
       }
     },
-    [onHazardDataLoading, onSearchComplete, toaster, toastIdFailedHazardData]
-  );
-
-  const fetchHazardData = useCallback(
-    async (coords: number[]) => {
-      return getHazardData(coords);
-    },
-    [getHazardData]
+    [onHazardDataLoading, onSearchComplete]
   );
 
   return {
     fetchHazardData,
-  }
+  };
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,10 @@ const config: Config = {
   testEnvironment: "./app/tests/FixJSDOMEnvironment.ts",
   // Add more setup options before each test is run
   setupFilesAfterEnv: ["<rootDir>/app/components/__mocks__/jest.setup.tsx"],
+  // Map the "@" alias to the app directory for importing ui components(ex. toaster)
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/app/$1",
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
# Description

- Related to https://github.com/sfbrigade/datasci-earthquake/issues/438

This PR makes the following changes:
- Moves data fetching logic into a shared hook so the `SearchBar` component focuses more on rendering
- `fetchHazardData` function is memoized within the new hook and is wrapped in `useCallback` with its dependencies to ensure the function always has access to the latest values, preventing it from becoming "stale."
- Adds unit tests for the `useHazardDataFetcher` hook
- Updates jest config to map the `@` alias to the app directory when running tests. `@` is used when importing ui components like `Toaster`

I think this should fix the issue linked above but not 100% sure. It should at least be an improvement to separate the data fetching logic.

Screen recording shows that existing behavior hasn't changed and we are fetching hazard data successfully.

https://github.com/user-attachments/assets/5711fafe-b794-4a04-855a-b6197b77a041



## Type of changes
- [ ] Bugfix
- [x] Chore
- [ ] New Feature

## Testing
- [x] I added automated tests
- [ ] I think tests are unnecessary

## How to test
- Select an address and see that the behavior is unchanged and we fetch hazard data and display the results
- Run tests using `npm test`

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)