### PR TITLE
bug/509/fix-width-on-mobile

### DIFF
--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -244,7 +244,13 @@ const SearchBar = ({
             <Input
               placeholder="Search San Francisco address"
               fontFamily="Inter, sans-serif"
-              fontSize={{ base: "md", sm: "md", md: "md", lg: "md" }}
+              fontSize={{
+                base: "md",
+                smDown: "sm",
+                sm: "md",
+                md: "md",
+                lg: "md",
+              }}
               size={{ base: "lg", md: "xl", xl: "xl" }}
               p={{
                 base: "0 10px 0 35px",

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -213,8 +213,7 @@ const SearchBar = ({
         >
           <InputGroup
             w={{
-              base: "303px",
-              smDown: "100%",
+              base: "100%",
               sm: "303px",
               md: "371px",
               lg: "417px",
@@ -245,8 +244,7 @@ const SearchBar = ({
               placeholder="Search San Francisco address"
               fontFamily="Inter, sans-serif"
               fontSize={{
-                base: "md",
-                smDown: "sm",
+                base: "sm",
                 sm: "md",
                 md: "md",
                 lg: "md",

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -212,7 +212,13 @@ const SearchBar = ({
           onRetrieve={handleRetrieve}
         >
           <InputGroup
-            w={{ base: "303px", sm: "303px", md: "371px", lg: "417px" }}
+            w={{
+              base: "303px",
+              smDown: "100%",
+              sm: "303px",
+              md: "371px",
+              lg: "417px",
+            }}
             mb={"24px"}
             data-testid="search-bar"
             startElement={


### PR DESCRIPTION
# Description

Changed base condition of InputGroup to 100% and base fontsize of input within InputGroup to sm, within search-bar form. This covers any screen width smaller than 480px.

#509

## Type of changes
- [X] Bugfix
- [ ] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [X] I think tests are unnecessary

## How to test

view deployment from mobile view

## Clean commits
- [X] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)