### PR TITLE
add Posthog environment variables to Generate .env action

### DIFF
--- a/.github/workflows/env_vars.yml
+++ b/.github/workflows/env_vars.yml
@@ -29,6 +29,8 @@ jobs:
         envkey_NODE_ENV: ${{ secrets.NODE_ENV }}
         envkey_NEXT_PUBLIC_CDN_URL: http://localhost:3000/data
         envkey_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        envkey_NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+        envkey_NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
 
         file_name: .env
         directory: './'


### PR DESCRIPTION
# Description

This ought to copy the new Posthog environment variables recently added to GitHub Secrets into the .env file.

#396 

## Type of changes
- [ ] Bugfix
- [x] Chore
- [ ] New Feature

## Testing
- [ ] I added automated tests
- [x] I think tests are unnecessary

## How to test

Run the GitHub action and see if the resulting .env.enc artifact contains the PostHog env vars.

## Clean commits
- [x] I plan to Squash and Merge
- [ ] My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)