### PR TITLE
chore/600/hazard-card-click-change

### DIFF
--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -69,38 +69,39 @@ const CardHazard: React.FC<CardHazardProps> = ({
         positioning={{
           placement: "bottom",
           flip: false,
-          offset: { crossAxis: 0, mainAxis: 24 },
+          offset: { crossAxis: -16, mainAxis: 24 },
+          sameWidth: true,
         }}
         closeOnEscape={true}
         closeOnInteractOutside={true}
         aria-label={`${hazard.title} information`}
       >
-        <Popover.Trigger h="full">
-          <VStack cursor={"pointer"} alignItems={"flex-start"} h="full">
-            <Card.Header p={0} marginBottom={"0.5em"} textAlign="left">
-              <Text
-                textStyle="cardTitle"
-                layerStyle="headerAlt"
-                fontWeight={"700"}
-              >
-                {title}
-              </Text>
-            </Card.Header>
-            <Card.Body textAlign="left" p={0} mb={"14px"}>
-              <Text textStyle="textMedium" layerStyle="text">
-                {description}
-              </Text>
-            </Card.Body>
-            <Card.Footer p={0} width={"100%"}>
-              <HStack justifyContent="space-between" width="100%">
+        <VStack alignItems={"flex-start"} h="full">
+          <Card.Header p={0} marginBottom={"0.5em"} textAlign="left">
+            <Text
+              textStyle="cardTitle"
+              layerStyle="headerAlt"
+              fontWeight={"700"}
+            >
+              {title}
+            </Text>
+          </Card.Header>
+          <Card.Body textAlign="left" p={0} mb={"14px"}>
+            <Text textStyle="textMedium" layerStyle="text">
+              {description}
+            </Text>
+          </Card.Body>
+          <Card.Footer p={0} width={"100%"}>
+            <HStack justifyContent="space-between" width="100%">
+              <Popover.Trigger>
                 <Text cursor={"pointer"} textDecoration={"underline"}>
                   More Info
                 </Text>
-                {hazardPill}
-              </HStack>
-            </Card.Footer>
-          </VStack>
-        </Popover.Trigger>
+              </Popover.Trigger>
+              {hazardPill}
+            </HStack>
+          </Card.Footer>
+        </VStack>
         <Portal>
           <Popover.Positioner>
             <Popover.Content maxHeight="unset">

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -69,7 +69,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
         positioning={{
           placement: "bottom",
           flip: false,
-          offset: { crossAxis: -16, mainAxis: 24 },
+          offset: { crossAxis: 18, mainAxis: 24 },
           sameWidth: true,
         }}
         closeOnEscape={true}


### PR DESCRIPTION
# Description

Changes to allow only the "more info" text to reveal popover. Should be temporary as popover may be removed entirely.

closes #600 

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

_testing description here: i.e. run app, go to x page, see that it does y_

## Clean commits
- (X) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
