### PR TITLE
Vercel serverless function CORS fix

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,6 +1,5 @@
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-from fastapi.middleware.cors import CORSMiddleware
 from backend.api.routers import (
     liquefaction_api,
     tsunami_api,
@@ -26,20 +25,6 @@ app.include_router(liquefaction_api.router)
 app.include_router(tsunami_api.router)
 app.include_router(soft_story_api.router)
 app.include_router(health_api.router)
-
-origins = [
-    "http://localhost",
-    "http://localhost:3000",
-]
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 
 # Global exception handler (ensures flush before serverless exit)
 @app.exception_handler(Exception)

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,10 @@
   "routes": [
     {
       "src": "/api/(.*)",
-      "dest": "api/index.py"
+      "dest": "api/index.py",
+      "headers": {
+        "Access-Control-Allow-Origin": "*"
+      }
     }
   ],
   "functions": {


### PR DESCRIPTION
I noticed that the "Access-Control-Allow-Origin" header was entirely missing from production api deployments. Reading through Vercel's documentation on [rewriting routes](https://vercel.com/docs/project-configuration#routes) and [CORS](https://vercel.com/guides/how-to-enable-cors), it looked like the functions were ignoring headers sent by the code itself.

Closes #418 

## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test

I deployed a clone of the production build, and made a test git branch [here](https://datasci-earthquake-git-test-33tmmm.vercel.app/) and another with the aforementioned changes made [here](https://datasci-earthquake-git-cors-33tmmm.vercel.app/). Although both APIs don't return any actual data, only the modified one returns a proper access control header and isn't blocked by CORS policy.

## Clean commits
- ( ) I plan to Squash and Merge
- (x) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
