### PR TITLE
Refactored popovers to accordion with polished display.

### DIFF
--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   HStack,
   Separator,
+  Accordion,
 } from "@chakra-ui/react";
 import { Hazards } from "../data/data";
 import CardHazard from "../components/card-hazard";
@@ -61,25 +62,27 @@ const ComponentsTestLib = () => {
         Hazards Card
       </Heading>
       <Text mb={6}>This section demonstrates Hazard Card component</Text>
-      <VStack gap={6} align="start">
-        <HStack w="100%">
-          {Hazards.map((hazard) => {
-            return (
-              <CardHazard
-                key={hazard.id}
-                hazard={hazard}
-                hazardData={{ exists: true, last_updated: "" }}
-                showData={true}
-                isHazardDataLoading={true}
-                toggledStates={toggledStates}
-                setToggledStates={setToggledStates}
-                setLayerToggleObj={setLayerToggleObj}
-              />
-            );
-          })}
-        </HStack>
-        <Separator mb={3} />
-      </VStack>
+      <Accordion.Root collapsible={true}>
+        <VStack gap={6} align="start">
+          <HStack w="100%">
+            {Hazards.map((hazard) => {
+              return (
+                <CardHazard
+                  key={hazard.id}
+                  hazard={hazard}
+                  hazardData={{ exists: true, last_updated: "" }}
+                  showData={true}
+                  isHazardDataLoading={true}
+                  toggledStates={toggledStates}
+                  setToggledStates={setToggledStates}
+                  setLayerToggleObj={setLayerToggleObj}
+                />
+              );
+            })}
+          </HStack>
+          <Separator mb={3} />
+        </VStack>
+      </Accordion.Root>
       <Text mb={6}>This section demonstrates Share menu component</Text>
       <VStack gap={6} align="start">
         <HStack w="100%">

--- a/app/components/__tests__/card-hazard.test.tsx
+++ b/app/components/__tests__/card-hazard.test.tsx
@@ -5,6 +5,7 @@ import { Hazards } from "../../data/data";
 import "@testing-library/jest-dom";
 import { Provider } from "../ui/provider";
 import "../__mocks__/match-media";
+import { Accordion } from "@chakra-ui/react";
 
 // eslint-disable-next-line react/display-name
 jest.mock("../pill.tsx", () => () => (
@@ -39,14 +40,16 @@ describe("CardHazard Component", () => {
   it("renders without crashing", () => {
     render(
       <Provider>
-        <CardHazard
-          hazard={Hazards[0]}
-          showData={true}
-          isHazardDataLoading={true}
-          toggledStates={toggledStates}
-          setToggledStates={setToggledStates}
-          setLayerToggleObj={setLayerToggleObj}
-        />
+        <Accordion.Root>
+          <CardHazard
+            hazard={Hazards[0]}
+            showData={true}
+            isHazardDataLoading={true}
+            toggledStates={toggledStates}
+            setToggledStates={setToggledStates}
+            setLayerToggleObj={setLayerToggleObj}
+          />
+        </Accordion.Root>
       </Provider>
     );
     expect(screen.getByText("Earthquake")).toBeInTheDocument();
@@ -55,14 +58,16 @@ describe("CardHazard Component", () => {
   it("displays the hazard title and description", () => {
     render(
       <Provider>
-        <CardHazard
-          hazard={Hazards[0]}
-          showData={true}
-          isHazardDataLoading={true}
-          toggledStates={toggledStates}
-          setToggledStates={setToggledStates}
-          setLayerToggleObj={setLayerToggleObj}
-        />
+        <Accordion.Root>
+          <CardHazard
+            hazard={Hazards[0]}
+            showData={true}
+            isHazardDataLoading={true}
+            toggledStates={toggledStates}
+            setToggledStates={setToggledStates}
+            setLayerToggleObj={setLayerToggleObj}
+          />{" "}
+        </Accordion.Root>
       </Provider>
     );
     expect(screen.getByText("Earthquake")).toBeInTheDocument();

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -99,7 +99,8 @@ const CardHazard: React.FC<CardHazardProps> = ({
       // boxShadow="0px 5px 6px #c8caceff"
       variant="elevated"
     >
-      <Accordion.Item border="none"
+      <Accordion.Item
+        border="none"
         /*
         closeOnEscape={true}
         closeOnInteractOutside={true}

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -100,11 +100,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
       // boxShadow="0px 5px 6px #c8caceff"
       variant="elevated"
     >
-      <Accordion.Item
-        border="none"
-        minH="154px"
-        value={hazard.name}
-      >
+      <Accordion.Item border="none" minH="154px" value={hazard.name}>
         <VStack alignItems={"flex-start"} flexGrow={1} minH="154px">
           <Card.Header
             w="102%"

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -7,7 +7,7 @@ import {
   Link,
   Card,
   Spinner,
-  Popover,
+  Accordion,
   Portal,
   Switch,
 } from "@chakra-ui/react";
@@ -99,16 +99,13 @@ const CardHazard: React.FC<CardHazardProps> = ({
       // boxShadow="0px 5px 6px #c8caceff"
       variant="elevated"
     >
-      <Popover.Root
-        positioning={{
-          placement: "bottom",
-          flip: false,
-          offset: { crossAxis: -12, mainAxis: 24 },
-          sameWidth: true,
-        }}
+      <Accordion.Item border="none"
+        /*
         closeOnEscape={true}
         closeOnInteractOutside={true}
-        aria-label={`${hazard.title} information`}
+        aria-label={`${hazard.title} information`} 
+      */
+        value={hazard.name}
       >
         <VStack alignItems={"flex-start"} flexGrow={1} h="full">
           <Card.Header
@@ -143,50 +140,43 @@ const CardHazard: React.FC<CardHazardProps> = ({
           </Card.Body>
           <Card.Footer p={0} width={"100%"}>
             <HStack justifyContent="space-between" width="100%">
-              <Popover.Trigger>
+              <Accordion.ItemTrigger p={0}>
                 <Text cursor={"pointer"} textDecoration={"underline"}>
                   More Info
                 </Text>
-              </Popover.Trigger>
+              </Accordion.ItemTrigger>
               {hazardPill}
             </HStack>
           </Card.Footer>
         </VStack>
-        <Portal>
-          <Popover.Positioner>
-            <Popover.Content maxHeight="unset">
-              <Popover.CloseTrigger
+        <Accordion.ItemContent maxHeight="unset">
+          {/* <Accordion.CloseTrigger
                 cursor="pointer"
                 position="absolute"
                 top="2"
                 right="2"
               >
                 <RxCross2 color="grey.900" size="20" data-testid="clear-icon" />
-              </Popover.CloseTrigger>
-              <Popover.Arrow>
-                <Popover.ArrowTip />
-              </Popover.Arrow>
-              <Popover.Body>
-                {buildHazardCardInfo()}
-                <Link
-                  display={"inline-block"}
-                  href={hazard.link.url}
-                  mt="4"
-                  target="_blank"
-                  textDecoration="underline"
-                  onClick={() =>
-                    posthog.capture("dataset-link-clicked", {
-                      link_name: hazard.link.label,
-                    })
-                  }
-                >
-                  {hazard.link.label}
-                </Link>
-              </Popover.Body>
-            </Popover.Content>
-          </Popover.Positioner>
-        </Portal>
-      </Popover.Root>
+              </Accordion.CloseTrigger> */}
+          <Accordion.ItemBody>
+            {buildHazardCardInfo()}
+            <Link
+              display={"inline-block"}
+              href={hazard.link.url}
+              mt="4"
+              target="_blank"
+              textDecoration="underline"
+              onClick={() =>
+                posthog.capture("dataset-link-clicked", {
+                  link_name: hazard.link.label,
+                })
+              }
+            >
+              {hazard.link.label}
+            </Link>
+          </Accordion.ItemBody>
+        </Accordion.ItemContent>
+      </Accordion.Item>
     </Card.Root>
   );
 };

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -10,6 +10,7 @@ import {
   Accordion,
   Portal,
   Switch,
+  Separator,
 } from "@chakra-ui/react";
 import posthog from "posthog-js";
 import Pill from "./pill";
@@ -70,7 +71,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
 
   const buildHazardCardInfo = () => {
     return hazard.info.map((infoItem, index) => (
-      <Text as="p" mt="4" key={index}>
+      <Text as="p" mt="1" key={index}>
         {infoItem}
       </Text>
     ));
@@ -101,14 +102,10 @@ const CardHazard: React.FC<CardHazardProps> = ({
     >
       <Accordion.Item
         border="none"
-        /*
-        closeOnEscape={true}
-        closeOnInteractOutside={true}
-        aria-label={`${hazard.title} information`} 
-      */
+        minH="154px"
         value={hazard.name}
       >
-        <VStack alignItems={"flex-start"} flexGrow={1} h="full">
+        <VStack alignItems={"flex-start"} flexGrow={1} minH="154px">
           <Card.Header
             w="102%"
             p={0}
@@ -141,7 +138,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
           </Card.Body>
           <Card.Footer p={0} width={"100%"}>
             <HStack justifyContent="space-between" width="100%">
-              <Accordion.ItemTrigger p={0}>
+              <Accordion.ItemTrigger p={0} w="initial">
                 <Text cursor={"pointer"} textDecoration={"underline"}>
                   More Info
                 </Text>
@@ -151,14 +148,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
           </Card.Footer>
         </VStack>
         <Accordion.ItemContent maxHeight="unset">
-          {/* <Accordion.CloseTrigger
-                cursor="pointer"
-                position="absolute"
-                top="2"
-                right="2"
-              >
-                <RxCross2 color="grey.900" size="20" data-testid="clear-icon" />
-              </Accordion.CloseTrigger> */}
+          <Separator mt="3" />
           <Accordion.ItemBody>
             {buildHazardCardInfo()}
             <Link

--- a/app/components/report-hazards.tsx
+++ b/app/components/report-hazards.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@chakra-ui/react";
+import { Accordion, Box } from "@chakra-ui/react";
 import CardHazard from "./card-hazard";
 import { Hazards } from "../data/data";
 import { CardContainer } from "./card-container";
@@ -22,25 +22,27 @@ const ReportHazards = ({
 }) => {
   return (
     <Box>
-      <CardContainer>
-        {Hazards.map((hazard, index) => {
-          return (
-            <CardHazard
-              key={hazard.id}
-              hazard={hazard}
-              hazardData={
-                addressHazardData?.[hazard.name as keyof HazardData] ??
-                undefined
-              }
-              showData={hazard.name in addressHazardData ? true : false}
-              isHazardDataLoading={isHazardDataLoading}
-              toggledStates={toggledStates}
-              setToggledStates={setToggledStates}
-              setLayerToggleObj={setLayerToggleObj}
-            />
-          );
-        })}
-      </CardContainer>
+      <Accordion.Root collapsible={true}>
+        <CardContainer>
+          {Hazards.map((hazard) => {
+            return (
+              <CardHazard
+                key={hazard.id}
+                hazard={hazard}
+                hazardData={
+                  addressHazardData?.[hazard.name as keyof HazardData] ??
+                  undefined
+                }
+                showData={hazard.name in addressHazardData ? true : false}
+                isHazardDataLoading={isHazardDataLoading}
+                toggledStates={toggledStates}
+                setToggledStates={setToggledStates}
+                setLayerToggleObj={setLayerToggleObj}
+              />
+            );
+          })}
+        </CardContainer>
+      </Accordion.Root>
     </Box>
   );
 };


### PR DESCRIPTION
# Description

Refactored card-hazard.tsx to replace popovers with accordions. 
Reference: https://www.figma.com/design/2yjQGc0lCYCbnfq5qotgEG/SafeHome-Design?node-id=1278-3050&p=f&t=cjKKTeJ99yysQWPI-0 

<img width="1499" height="763" alt="Screenshot 2025-09-23 at 12 05 18 PM" src="https://github.com/user-attachments/assets/3c5d0500-7e0e-411e-9ca5-edee8776eebb" />

<img width="1494" height="756" alt="Screenshot 2025-09-23 at 12 06 26 PM" src="https://github.com/user-attachments/assets/56819a44-2705-47f6-8854-20dba2993c7e" />


closes #644 

## Type of changes
- ( ) Bugfix
- (x) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test

Open the latest deployment and click the 'more info' button. 

## Clean commits
- (x) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
