### PR TITLE
Hazard card's display on mobile

### DIFF
--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { toaster } from "@/components/ui/toaster";
 import Map from "./map";
 import ReportHazards from "./report-hazards";
+import MobileReportHazards from "./mobile-report-hazards";
 import { FeatureCollection, Geometry } from "geojson";
 import HomeHeader from "./home-header";
 import { useSearchParams } from "next/navigation";
@@ -39,11 +40,6 @@ const isErrorResult = (data: unknown): data is ErrorResult => {
   );
 };
 
-// const testingMobile = () => {
-//   if (window.innerWidth <= 480) return true;
-//   else return false;
-// };
-
 const AddressMapper: React.FC<AddressMapperProps> = ({
   softStoryData,
   tsunamiData,
@@ -72,13 +68,12 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
     layerId: "",
     toggleState: true,
   });
+  const [showHazards, setShowHazards] = useState(false);
   const [isSearchComplete, setSearchComplete] = useState(false);
   const [currentView, setCurrentView] = useState("");
   const toastIdDataLoadFailed = "data-load-failed";
   const coordinatesRef = useRef<number[] | null>(null);
   const router = useRouter();
-
-  console.log(currentView);
 
   const { fetchHazardData } = useHazardDataFetcher({
     setSearchComplete,
@@ -184,13 +179,15 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
   }, [softStoryData, tsunamiData, liquefactionData]);
 
   useEffect(() => {
-    if (window.innerWidth <= 480) setCurrentView("mobile");
-    else setCurrentView("desktop");
+    if (currentView === "") {
+      if (window.innerWidth <= 480) setCurrentView("mobile");
+      else setCurrentView("desktop");
+    }
     window.addEventListener("resize", handleResize);
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, []);
+  }, [currentView]);
 
   return (
     <>
@@ -217,6 +214,16 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
                 addressHazardData={addressHazardData}
                 isHazardDataLoading={isHazardDataLoading}
                 toggledStates={toggledStates}
+                setToggledStates={setToggledStates}
+                setLayerToggleObj={setLayerToggleObj}
+              />
+            ) : currentView === "mobile" ? (
+              <MobileReportHazards
+                showHazards={showHazards}
+                addressHazardData={addressHazardData}
+                isHazardDataLoading={isHazardDataLoading}
+                toggledStates={toggledStates}
+                setShowHazards={setShowHazards}
                 setToggledStates={setToggledStates}
                 setLayerToggleObj={setLayerToggleObj}
               />

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -39,6 +39,11 @@ const isErrorResult = (data: unknown): data is ErrorResult => {
   );
 };
 
+// const testingMobile = () => {
+//   if (window.innerWidth <= 480) return true;
+//   else return false;
+// };
+
 const AddressMapper: React.FC<AddressMapperProps> = ({
   softStoryData,
   tsunamiData,
@@ -68,9 +73,12 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
     toggleState: true,
   });
   const [isSearchComplete, setSearchComplete] = useState(false);
+  const [currentView, setCurrentView] = useState("");
   const toastIdDataLoadFailed = "data-load-failed";
   const coordinatesRef = useRef<number[] | null>(null);
   const router = useRouter();
+
+  console.log(currentView);
 
   const { fetchHazardData } = useHazardDataFetcher({
     setSearchComplete,
@@ -102,6 +110,12 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
     },
     [fetchHazardData]
   );
+
+  const handleResize = () => {
+    if (window.innerWidth <= 480) {
+      setCurrentView("mobile");
+    } else setCurrentView("desktop");
+  };
 
   const handleSearchChange = useCallback(
     (coords: number[], address: string) => {
@@ -169,6 +183,15 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
     }
   }, [softStoryData, tsunamiData, liquefactionData]);
 
+  useEffect(() => {
+    if (window.innerWidth <= 480) setCurrentView("mobile");
+    else setCurrentView("desktop");
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
   return (
     <>
       <HomeHeader
@@ -189,13 +212,15 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
       >
         <Box h="100%" overflow="hidden">
           <Box zIndex={10} top={0} position="absolute">
-            <ReportHazards
-              addressHazardData={addressHazardData}
-              isHazardDataLoading={isHazardDataLoading}
-              toggledStates={toggledStates}
-              setToggledStates={setToggledStates}
-              setLayerToggleObj={setLayerToggleObj}
-            />
+            {currentView === "desktop" ? (
+              <ReportHazards
+                addressHazardData={addressHazardData}
+                isHazardDataLoading={isHazardDataLoading}
+                toggledStates={toggledStates}
+                setToggledStates={setToggledStates}
+                setLayerToggleObj={setLayerToggleObj}
+              />
+            ) : null}
           </Box>
           <Map
             coordinates={coordinates || defaultCoords}

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -180,8 +180,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
 
   useEffect(() => {
     if (currentView === "") {
-      if (window.innerWidth <= 480) setCurrentView("mobile");
-      else setCurrentView("desktop");
+      handleResize();
     }
     window.addEventListener("resize", handleResize);
     return () => {

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -107,9 +107,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
   );
 
   const handleResize = () => {
-    if (window.innerWidth <= 480) {
-      setCurrentView("mobile");
-    } else setCurrentView("desktop");
+    setCurrentView(window.innerWidth <= 480 ? "mobile" : "desktop");
   };
 
   const handleSearchChange = useCallback(

--- a/app/components/card-hazard.tsx
+++ b/app/components/card-hazard.tsx
@@ -17,7 +17,7 @@ import { RxCross2 } from "react-icons/rx";
 import { PillData, LayerIds } from "../data/data";
 import { FaCircle, FaSquareFull } from "react-icons/fa";
 import { KeyElem } from "./key-elem";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { LayerToggleObjProps } from "./address-mapper";
 interface CardHazardProps {
   hazard: {
@@ -54,6 +54,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
     falseData: "No Data",
     noData: "No Data",
   };
+  const [isMoreInfo, setIsMoreInfo] = useState(false);
 
   const hazardPill = isHazardDataLoading ? (
     <Spinner size="xs" />
@@ -105,6 +106,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
         closeOnEscape={true}
         closeOnInteractOutside={true}
         aria-label={`${hazard.title} information`}
+        onOpenChange={(e) => setIsMoreInfo(e.open)}
       >
         <VStack alignItems={"flex-start"} flexGrow={1} h="full">
           <Card.Header
@@ -160,7 +162,7 @@ const CardHazard: React.FC<CardHazardProps> = ({
                     "2xl": "md",
                   }}
                 >
-                  More Info
+                  {!isMoreInfo ? "More info" : "Less info"}
                 </Text>
               </Popover.Trigger>
               {hazardPill}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -8,7 +8,7 @@ const Footer = () => {
       return (
         <Text
           key={index}
-          textStyle="textSmall"
+          textStyle="textXSmall"
           layerStyle="text"
           lineHeight="shorter"
           color="white"
@@ -38,7 +38,7 @@ const Footer = () => {
           maxW={{ base: "100%", lg: "672px" }}
           gap="24px"
         >
-          <Text textStyle="textSmall" layerStyle="text" color="white">
+          <Text textStyle="textXSmall" layerStyle="text" color="white">
             © 2025 SF Civic Tech
           </Text>
           {buildDisclaimers()}

--- a/app/components/home-header.tsx
+++ b/app/components/home-header.tsx
@@ -43,7 +43,7 @@ const HomeHeader = ({
       as="header"
       bg="gradient.blue"
       p={{
-        base: "18px 32px 22px 48px",
+        base: "18px 32px 22px 32px",
         "2xl": "22px 48px 26px 48px",
       }}
     >

--- a/app/components/key-elem.tsx
+++ b/app/components/key-elem.tsx
@@ -4,15 +4,21 @@ type KeyElemProps = {
   name: string;
   color: string;
   icon: React.ReactNode;
+  isMobile?: boolean;
 };
 
-export const KeyElem = ({ name, color, icon }: KeyElemProps) => {
+export const KeyElem = ({ name, color, icon, isMobile }: KeyElemProps) => {
   return (
     <Stack direction="row" alignItems="center">
-      <Icon size="md" color={color}>
+      <Icon size={isMobile ? "sm" : "md"} color={color}>
         {icon}
       </Icon>
-      <Text textStyle="textMedium" layerStyle="headerAlt" fontWeight="700">
+      <Text
+        textStyle={isMobile ? "textSmall" : "textMedium"}
+        layerStyle="headerAlt"
+        fontWeight="700"
+        whiteSpace={"nowrap"}
+      >
         {name}
       </Text>
     </Stack>

--- a/app/components/mobile-card-hazard.tsx
+++ b/app/components/mobile-card-hazard.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import {
+  Text,
+  HStack,
+  VStack,
+  Link,
+  Card,
+  Spinner,
+  Accordion,
+  Switch,
+  Separator,
+  Collapsible,
+} from "@chakra-ui/react";
+import posthog from "posthog-js";
+import Pill from "./pill";
+import { PillData, LayerIds } from "../data/data";
+import { FaCircle, FaSquareFull } from "react-icons/fa";
+import { KeyElem } from "./key-elem";
+import { Dispatch, SetStateAction } from "react";
+import { LayerToggleObjProps } from "./address-mapper";
+interface CardHazardProps {
+  hazard: {
+    id: number;
+    name: string;
+    title: string;
+    description: string;
+    info: string[];
+    link: { label: string; url: string };
+    icon: string;
+    iconColor: string;
+  };
+  hazardData?: { exists?: boolean; last_updated?: string };
+  showData: boolean;
+  isHazardDataLoading: boolean;
+  toggledStates: boolean[];
+  setToggledStates: Dispatch<SetStateAction<boolean[]>>;
+  setLayerToggleObj: Dispatch<SetStateAction<LayerToggleObjProps>>;
+}
+
+const MobileCardHazard: React.FC<CardHazardProps> = ({
+  hazard,
+  hazardData,
+  showData,
+  isHazardDataLoading,
+  toggledStates,
+  setToggledStates,
+  setLayerToggleObj,
+}) => {
+  const { id, title, name, description, icon, iconColor } = hazard;
+  const { exists, last_updated: date } = hazardData || {};
+  const pillTextOptions = PillData.find((object) => object.name === name) ?? {
+    trueData: "No Data",
+    falseData: "No Data",
+    noData: "No Data",
+  };
+
+  const hazardPill = isHazardDataLoading ? (
+    <Spinner size="xs" />
+  ) : showData ? (
+    <Pill
+      exists={exists}
+      trueData={pillTextOptions.trueData}
+      falseData={pillTextOptions.falseData}
+      noData={pillTextOptions.noData}
+    />
+  ) : (
+    ""
+  );
+
+  const buildHazardCardInfo = () => {
+    return hazard.info.map((infoItem, index) => (
+      <Text as="p" mt="1.5" key={index} textStyle="textXSmall">
+        {infoItem}
+      </Text>
+    ));
+  };
+
+  const handleSwitchClick = (num: number, checked: boolean) => {
+    const newArray = [];
+    const obj = {
+      layerId: LayerIds[num],
+      toggleState: checked,
+    };
+    for (let i = 0; i < toggledStates.length; i++) {
+      if (i === num) newArray.push(checked);
+      else newArray.push(toggledStates[i]);
+    }
+    setToggledStates(newArray);
+    setLayerToggleObj(obj);
+  };
+
+  return (
+    <Card.Root
+      flex={1}
+      w="86vw"
+      p={"8px 12px"}
+      // boxShadow="0px 5px 6px #c8caceff"
+      variant="elevated"
+      borderRadius={0}
+    >
+      <Accordion.Item border="none" w="100%" value={hazard.name}>
+        <Accordion.ItemTrigger p={0} w={"100%"}>
+          <Card.Header
+            w="98%"
+            p={0}
+            // mb={"0.2em"}
+            textAlign="left"
+            flexDirection="row"
+            justifyContent="space-between"
+          >
+            <KeyElem
+              name={title}
+              color={iconColor}
+              icon={icon === "circle" ? <FaCircle /> : <FaSquareFull />}
+              isMobile={true}
+            />
+            {hazardPill}
+          </Card.Header>
+        </Accordion.ItemTrigger>
+        <Accordion.ItemContent maxHeight="unset">
+          <Accordion.ItemBody pb={0}>
+            <Collapsible.Root>
+              <Card.Body textAlign="left" p={0}>
+                <HStack justifyContent="space-between">
+                  <Text textStyle="textXSmall" layerStyle="text">
+                    {description}
+                  </Text>
+                  <Switch.Root
+                    size="lg"
+                    colorPalette="blue"
+                    checked={toggledStates[id]}
+                    onCheckedChange={(e) => handleSwitchClick(id, e.checked)}
+                    defaultChecked
+                  >
+                    <Switch.HiddenInput />
+                    <Switch.Control />
+                    <Switch.Label />
+                  </Switch.Root>
+                </HStack>
+              </Card.Body>
+              <Card.Footer p={0} width={"100%"}>
+                <Collapsible.Trigger>
+                  <Text
+                    textStyle="textXSmall"
+                    cursor={"pointer"}
+                    textDecoration={"underline"}
+                    fontWeight={"bold"}
+                  >
+                    More Info
+                  </Text>
+                </Collapsible.Trigger>
+              </Card.Footer>
+              <Collapsible.Content>
+                <Separator mt="2" />
+                {buildHazardCardInfo()}
+                <Link
+                  display={"inline-block"}
+                  href={hazard.link.url}
+                  mt="4"
+                  target="_blank"
+                  textDecoration="underline"
+                  onClick={() =>
+                    posthog.capture("dataset-link-clicked", {
+                      link_name: hazard.link.label,
+                    })
+                  }
+                  textStyle={"textXSmall"}
+                  fontWeight={"bold"}
+                >
+                  {hazard.link.label}
+                </Link>
+              </Collapsible.Content>
+            </Collapsible.Root>
+          </Accordion.ItemBody>
+        </Accordion.ItemContent>
+      </Accordion.Item>
+    </Card.Root>
+  );
+};
+
+export default MobileCardHazard;

--- a/app/components/mobile-card-hazard.tsx
+++ b/app/components/mobile-card-hazard.tsx
@@ -17,7 +17,7 @@ import Pill from "./pill";
 import { PillData, LayerIds } from "../data/data";
 import { FaCircle, FaSquareFull } from "react-icons/fa";
 import { KeyElem } from "./key-elem";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 import { LayerToggleObjProps } from "./address-mapper";
 interface CardHazardProps {
   hazard: {
@@ -54,6 +54,7 @@ const MobileCardHazard: React.FC<CardHazardProps> = ({
     falseData: "No Data",
     noData: "No Data",
   };
+  const [isMoreInfo, setIsMoreInfo] = useState(false);
 
   const hazardPill = isHazardDataLoading ? (
     <Spinner size="xs" />
@@ -77,17 +78,13 @@ const MobileCardHazard: React.FC<CardHazardProps> = ({
   };
 
   const handleSwitchClick = (num: number, checked: boolean) => {
-    const newArray = [];
-    const obj = {
+    const newArray = [...toggledStates];
+    newArray[num] = checked;
+    setToggledStates(newArray);
+    setLayerToggleObj({
       layerId: LayerIds[num],
       toggleState: checked,
-    };
-    for (let i = 0; i < toggledStates.length; i++) {
-      if (i === num) newArray.push(checked);
-      else newArray.push(toggledStates[i]);
-    }
-    setToggledStates(newArray);
-    setLayerToggleObj(obj);
+    });
   };
 
   return (
@@ -99,12 +96,11 @@ const MobileCardHazard: React.FC<CardHazardProps> = ({
       variant="elevated"
       borderRadius={0}
     >
-      <Accordion.Item border="none" w="100%" value={hazard.name}>
+      <Accordion.Item border="none" w="98%" value={hazard.name}>
         <Accordion.ItemTrigger p={0} w={"100%"}>
           <Card.Header
-            w="98%"
+            w="100%"
             p={0}
-            // mb={"0.2em"}
             textAlign="left"
             flexDirection="row"
             justifyContent="space-between"
@@ -120,7 +116,7 @@ const MobileCardHazard: React.FC<CardHazardProps> = ({
         </Accordion.ItemTrigger>
         <Accordion.ItemContent maxHeight="unset">
           <Accordion.ItemBody pb={0}>
-            <Collapsible.Root>
+            <Collapsible.Root onOpenChange={(e) => setIsMoreInfo(e.open)}>
               <Card.Body textAlign="left" p={0}>
                 <HStack justifyContent="space-between">
                   <Text textStyle="textXSmall" layerStyle="text">
@@ -147,7 +143,7 @@ const MobileCardHazard: React.FC<CardHazardProps> = ({
                     textDecoration={"underline"}
                     fontWeight={"bold"}
                   >
-                    More Info
+                    {!isMoreInfo ? "More info" : "Less info"}
                   </Text>
                 </Collapsible.Trigger>
               </Card.Footer>

--- a/app/components/mobile-report-hazards.tsx
+++ b/app/components/mobile-report-hazards.tsx
@@ -1,0 +1,97 @@
+import {
+  Accordion,
+  Box,
+  Button,
+  Icon,
+  Menu,
+  Portal,
+  Span,
+} from "@chakra-ui/react";
+import MobileCardHazard from "./mobile-card-hazard";
+import { Hazards } from "../data/data";
+import { Dispatch, SetStateAction } from "react";
+import { LayerToggleObjProps } from "./address-mapper";
+import { FaAngleUp, FaAngleDown } from "react-icons/fa6";
+
+type HazardData = { softStory?: any; tsunami?: any; liquefaction?: any };
+
+const MobileReportHazards = ({
+  showHazards,
+  addressHazardData,
+  isHazardDataLoading,
+  toggledStates,
+  setShowHazards,
+  setToggledStates,
+  setLayerToggleObj,
+}: {
+  showHazards: boolean;
+  addressHazardData: HazardData;
+  isHazardDataLoading: boolean;
+  toggledStates: boolean[];
+  setShowHazards: Dispatch<SetStateAction<boolean>>;
+  setToggledStates: Dispatch<SetStateAction<boolean[]>>;
+  setLayerToggleObj: Dispatch<SetStateAction<LayerToggleObjProps>>;
+}) => {
+  return (
+    <Menu.Root
+      positioning={{ flip: false }}
+      onOpenChange={() => setShowHazards(!showHazards)}
+    >
+      <Box
+        pt="36px"
+        px={{ base: "32px", md: "32px", xl: "36px" }}
+        zIndex={10}
+        w="full"
+        position={"relative"}
+      >
+        <Menu.Trigger asChild>
+          <Button
+            textStyle={"textMedium"}
+            layerStyle={"mobileButton"}
+            // mb="10px"
+            fontWeight="700"
+            boxShadow="0px 0px 3px #c8caceff"
+          >
+            <Span mr="8px">Legend</Span>
+            {!showHazards ? (
+              <Icon size={"sm"}>
+                <FaAngleDown />
+              </Icon>
+            ) : (
+              <Icon size={"sm"}>
+                <FaAngleUp />
+              </Icon>
+            )}
+          </Button>
+        </Menu.Trigger>
+        <Portal>
+          <Menu.Positioner w="90%">
+            <Menu.Content p={0} borderRadius="15px" py={3} w="95%">
+              <Accordion.Root collapsible={true} w="100%">
+                {Hazards.map((hazard) => {
+                  return (
+                    <MobileCardHazard
+                      key={hazard.id}
+                      hazard={hazard}
+                      hazardData={
+                        addressHazardData?.[hazard.name as keyof HazardData] ??
+                        undefined
+                      }
+                      showData={hazard.name in addressHazardData ? true : false}
+                      isHazardDataLoading={isHazardDataLoading}
+                      toggledStates={toggledStates}
+                      setToggledStates={setToggledStates}
+                      setLayerToggleObj={setLayerToggleObj}
+                    />
+                  );
+                })}
+              </Accordion.Root>
+            </Menu.Content>
+          </Menu.Positioner>
+        </Portal>
+      </Box>
+    </Menu.Root>
+  );
+};
+
+export default MobileReportHazards;

--- a/app/components/mobile-report-hazards.tsx
+++ b/app/components/mobile-report-hazards.tsx
@@ -35,20 +35,13 @@ const MobileReportHazards = ({
   return (
     <Menu.Root
       positioning={{ flip: false }}
-      onOpenChange={() => setShowHazards(!showHazards)}
+      onOpenChange={(e) => setShowHazards(e.open)}
     >
-      <Box
-        pt="36px"
-        px={{ base: "32px", md: "32px", xl: "36px" }}
-        zIndex={10}
-        w="full"
-        position={"relative"}
-      >
+      <Box pt="36px" px="28px" zIndex={10} position="relative">
         <Menu.Trigger asChild>
           <Button
             textStyle={"textMedium"}
             layerStyle={"mobileButton"}
-            // mb="10px"
             fontWeight="700"
             boxShadow="0px 0px 3px #c8caceff"
           >
@@ -65,9 +58,9 @@ const MobileReportHazards = ({
           </Button>
         </Menu.Trigger>
         <Portal>
-          <Menu.Positioner w="90%">
-            <Menu.Content p={0} borderRadius="15px" py={3} w="95%">
-              <Accordion.Root collapsible={true} w="100%">
+          <Menu.Positioner>
+            <Menu.Content p={0} borderRadius="15px" py="12px" w="100%">
+              <Accordion.Root collapsible={true}>
                 {Hazards.map((hazard) => {
                   return (
                     <MobileCardHazard

--- a/app/components/pill.tsx
+++ b/app/components/pill.tsx
@@ -37,6 +37,7 @@ const Pill: React.FC<PillProps> = ({ exists, trueData, falseData, noData }) => {
         color="white"
         p="2px 12px 2px 12px"
         borderRadius="full"
+        whiteSpace={"nowrap"}
       >
         {getLabel()}
       </Text>

--- a/app/components/report-address.tsx
+++ b/app/components/report-address.tsx
@@ -11,7 +11,7 @@ const ReportAddress: React.FC<ReportAddressProps> = ({ searchedAddress }) => {
       alignItems={{ base: "flex-start", md: "center" }}
       gap={{ base: 1, md: 1 }} // TODO FIXME: double check if this should be "9px", as commented out above
     >
-      <Text textStyle="headerMedium" layerStyle="headerMain" fontSize="3xl">
+      <Text textStyle="headerMedium" layerStyle="headerMain">
         Report for {searchedAddress}
       </Text>
     </Stack>

--- a/app/components/report-hazards.tsx
+++ b/app/components/report-hazards.tsx
@@ -23,7 +23,7 @@ const ReportHazards = ({
   return (
     <Box>
       <CardContainer>
-        {Hazards.map((hazard, index) => {
+        {Hazards.map((hazard) => {
           return (
             <CardHazard
               key={hazard.id}

--- a/app/components/share.tsx
+++ b/app/components/share.tsx
@@ -34,7 +34,7 @@ const Share = () => {
 
   return (
     <Button
-      aria-label="Copy link"
+      aria-label="Copy link to this report"
       variant="ghost"
       onClick={copyLinkToClipBoard}
       background={"transparent"}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -74,7 +74,7 @@ const textStyles = defineTextStyles({
     },
   },
   textXSmall: {
-    description: "text small",
+    description: "text extra small",
     value: {
       fontFamily: "body",
       fontSize: "xs",

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -69,6 +69,14 @@ const textStyles = defineTextStyles({
     description: "text small",
     value: {
       fontFamily: "body",
+      fontSize: "sm",
+      fontWeight: "normal",
+    },
+  },
+  textXSmall: {
+    description: "text small",
+    value: {
+      fontFamily: "body",
       fontSize: "xs",
       fontWeight: "normal",
     },
@@ -138,6 +146,10 @@ const layerStyles = defineLayerStyles({
   list: {
     description: "list",
     value: { paddingLeft: "6", marginTop: "2" },
+  },
+  mobileButton: {
+    description: "mobile button",
+    value: { color: "black", bg: "white", borderRadius: "30px" },
   },
 });
 


### PR DESCRIPTION
# Description

Changes the functionality and appearance of hazard cards on mobile, in accordance to the Figma -> https://www.figma.com/design/2yjQGc0lCYCbnfq5qotgEG/SafeHome-Design?node-id=1278-3050&t=Xoxd3ABIpYVms2fP-0

<img width="1920" height="1040" alt="Capture11" src="https://github.com/user-attachments/assets/e7dd6db3-e83c-4503-9b33-b96580684009" />

<img width="1920" height="1040" alt="Capture12" src="https://github.com/user-attachments/assets/01f7af42-d8ae-4a85-8232-a5bcce98ecf0" />

<img width="1920" height="1040" alt="Capture13" src="https://github.com/user-attachments/assets/e85cdd0d-49cc-46f7-a787-161990bf03eb" />

<img width="1920" height="1040" alt="Capture14" src="https://github.com/user-attachments/assets/dc61b7ef-0f23-487c-a260-2fb167021d3b" />

closes #659

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

Open latest deployment, and use web browsers provided devtools/relevant tools to view webpage from mobile resolution. Viewing deployment from a phone should also work.

## Clean commits
- (X) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
