### PR TITLE
chore/661/map-resizing-and-whitespace

### DIFF
--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -179,13 +179,15 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
       <Box
         w="full"
         h={{
-          base: "980px",
-          md: "685px",
-          "2xl": "765px",
+          base: "calc(100vh - 198px - 32px)",
+          md: "calc(100vh - 175px - 32px)",
+          xl: "calc(100vh - 141px - 32px)",
+          "2xl": "calc(100vh - 149px - 32px)",
         }}
         m="auto"
+        position="relative"
       >
-        <Box h="100%" overflow="hidden" position="relative">
+        <Box h="100%" overflow="hidden">
           <Box zIndex={10} top={0} position="absolute">
             <ReportHazards
               addressHazardData={addressHazardData}


### PR DESCRIPTION
# Description

Provides more consistent whitespace across all breakpoints and heights. Changes sizing of map from hardcoded pixel amounts to more responsive, calculation based measurement.  

closes #661
closes #652 

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

open latest deployment, and observe whitespace beneath map across all breakpoints and height changes. the whitespace should remain a consistent 32px height.

## Clean commits
- (X) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
