### PR TITLE
add dev_docker case to set reload_flag

### DIFF
--- a/backend/etl/startup.sh
+++ b/backend/etl/startup.sh
@@ -34,7 +34,7 @@ echo "===== startup.sh finished ====="
 
 # Start FastAPI
 RELOAD_FLAG=""
-if [ "${ENVIRONMENT}" = "development" ]; then
+if [ "${ENVIRONMENT}" = "development" ] || [ "${ENVIRONMENT}" = "dev_docker" ]; then
   RELOAD_FLAG="--reload"
 fi
 echo "Starting FastAPI server"


### PR DESCRIPTION
# Description

_add a short description_
adds "or if the environment is "dev_docker" also set the uvicorn reload flag. Considered shifting to "case" to future-proof for easily adding other environments in the future, but used 'or' for minimal diff and lack of anticipation of many other cases. In discussion in ChatGPT5 conversation, it suggested use of "$(ENVIRONMENT:-)" in the line as a safe default guard, however I chose to leave it out because it seems in the development context you would want the "ENVIRONMENT: unbound variable" error if for some reason your environment wasn't set. I defer to reviewer judgment as this is new terrain for me.

_reference to relevant issue_
#679 
## Type of changes
- ( X) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X ) I think tests are unnecessary

## How to test

_testing description here: i.e. run app, go to x page, see that it does y_
make a change that would trigger a uvicorn reload while running app in docker desktop and see if reloads

## Clean commits
- ( X) I plan to Squash and Merge
- (X ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
