### PR TITLE
feat/688/first-card-expanded

### DIFF
--- a/app/components/mobile-report-hazards.tsx
+++ b/app/components/mobile-report-hazards.tsx
@@ -60,7 +60,7 @@ const MobileReportHazards = ({
         <Portal>
           <Menu.Positioner>
             <Menu.Content p={0} borderRadius="15px" py="12px" w="100%">
-              <Accordion.Root collapsible={true}>
+              <Accordion.Root collapsible={true} defaultValue={["softStory"]}>
                 {Hazards.map((hazard) => {
                   return (
                     <MobileCardHazard

--- a/app/components/mobile-report-hazards.tsx
+++ b/app/components/mobile-report-hazards.tsx
@@ -60,7 +60,10 @@ const MobileReportHazards = ({
         <Portal>
           <Menu.Positioner>
             <Menu.Content p={0} borderRadius="15px" py="12px" w="100%">
-              <Accordion.Root collapsible={true} defaultValue={["softStory"]}>
+              <Accordion.Root
+                collapsible={true}
+                defaultValue={[Hazards[0].name]}
+              >
                 {Hazards.map((hazard) => {
                   return (
                     <MobileCardHazard

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -98,12 +98,12 @@ const Home = async () => {
                 withstand shaking.
               </List.Item>
               <List.Item>
-                San Francisco’s Mandatory Soft Story Retrofit Ordinance ,
-                enacted in 2013, requires all multi-unit soft story buildings
-                built before 1978 to be retrofitted in order to minimize the
-                risk of earthquake damage. Soft-story homes with 1 to 4 units
-                are still vulnerable to earthquake damage, even though the
-                ordinance does not legally require them to be retrofitted.
+                San Francisco’s Mandatory Soft Story Retrofit Ordinance, enacted
+                in 2013, requires all multi-unit soft story buildings built
+                before 1978 to be retrofitted in order to minimize the risk of
+                earthquake damage. Soft-story homes with 1 to 4 units are still
+                vulnerable to earthquake damage, even though the ordinance does
+                not legally require them to be retrofitted.
               </List.Item>
             </List.Root>
 


### PR DESCRIPTION
# Description

A simple change that causes the mobile view's first hazard card (Soft Story) to be expanded by default whenever the hazard cards are displayed.

closes #688

## Type of changes
- ( ) Bugfix
- ( ) Chore
- (X) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

Open latest deployment, view site from mobile viewpoint (using devtools) and click the "legend" button to display hazard cards. The Soft Story hazard card should be expanded by default.

## Clean commits
- (X) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
