### PR TITLE
Changed ETL to only run when data tables don't exist or are empty

### DIFF
--- a/backend/database/init_db.py
+++ b/backend/database/init_db.py
@@ -6,19 +6,21 @@ SQLAlchemy. It includes functions to create, drop, and check the
 existence of tables in the database. 
 
 Functions:
-    init_db(): Creates all tables defined in the SQLAlchemy `Base` 
-               metadata.  Drops existing tables if they already exist.
+    init_db(): Ensures that all tables defined in the SQLAlchemy `Base` 
+               metadata exist. Print per-table ETL signals indicating which
+               tables need ETL.
     drop_db(): Drops all tables defined in the SQLAlchemy `Base` 
                metadata. Use cautiously because this action is 
                irreversible.
     check_tables_exist(): Checks if all ETL-related tables exist in the database.
-    check_tables_empty(): Checks if any main tables are empty.
+    check_tables_empty(): Checks if any main tables are empty. Returns a list 
+                          of names of empty tables.
 
 Usage:
     Run this script in docker to initialize the database by creating 
     all necessary tables.  If existing tables are detected but are empty,
-    they will be populated.  If tables exist and are not empty, the ETL
-    process will be skipped.
+    any empty tables will be populated. If all tables exist and are not
+    empty, the ETL process will be skipped entirely.
 
 Example:
     $ docker exec -it datasci-earthquake-backend-1 python backend/database/init_db.py
@@ -48,14 +50,14 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 def init_db():
     if not check_tables_exist():
         Base.metadata.create_all(bind=engine)
-        print("Database tables created. ETL should run to populate data.")
-    elif check_tables_empty():
-        print(
-            "Tables exist but at least one is empty. ETL should run to populate data."
-        )
+        print("Database tables created.")
+
+    empty_tables = check_tables_empty()
+    if empty_tables:
+        for table_name in empty_tables:
+            print(f"ETL_REQUIRED:{table_name}")
     else:
-        print("Tables exist and are populated.")
-        print("SKIP_ETL")
+        print("All required tables exist and are populated.")
 
 
 def drop_db():
@@ -78,11 +80,12 @@ def check_tables_exist():
 
 # LandslideZone is not being used, and isn't included in this check.
 def check_tables_empty():
+    empty_tables = []
     with SessionLocal() as session:
         for table in table_classes:
             if session.query(table).first() is None:
-                return True
-    return False
+                empty_tables.append(table.__tablename__)
+    return empty_tables
 
 
 if __name__ == "__main__":

--- a/backend/database/init_db.py
+++ b/backend/database/init_db.py
@@ -12,15 +12,17 @@ Functions:
                metadata. Use cautiously because this action is 
                irreversible.
     check_tables_exist(): Checks if any tables exist in the database.
+    check_tables_empty(): Checks if any main tables are empty.
 
 Usage:
     Run this script in docker to initialize the database by creating 
-    all necessary tables.  If existing tables are detected, they will 
-    be dropped and recreated.
+    all necessary tables.  If existing tables are detected but are empty,
+    they will be populated.  If tables exist and are not empty, the ETL
+    process will be skipped.
 
 Example:
     $ docker exec -it datasci-earthquake-backend-1 python backend/database/init_db.py
-    Database tables created.
+    Database tables created. ETL should run to populate data.
 
 Note:
     The `Base` object should be imported from your SQLAlchemy model 
@@ -34,17 +36,26 @@ Caution:
 from backend.api.models.base import Base
 from sqlalchemy import inspect
 from backend.database.session import engine
+from sqlalchemy.orm import sessionmaker
 from backend.api.models.tsunami import TsunamiZone
 from backend.api.models.landslide_zones import LandslideZone
 from backend.api.models.liquefaction_zones import LiquefactionZone
 from backend.api.models.soft_story_properties import SoftStoryProperty
 
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
 
 def init_db():
-    if check_tables_exist():
-        drop_db()
-    Base.metadata.create_all(bind=engine)
-    print("Database tables created.")
+    if not check_tables_exist():
+        Base.metadata.create_all(bind=engine)
+        print("Database tables created. ETL should run to populate data.")
+    elif check_tables_empty():
+        print(
+            "Tables exist but at least one is empty. ETL should run to populate data."
+        )
+    else:
+        print("Tables exist and are populated.")
+        print("SKIP_ETL")
 
 
 def drop_db():
@@ -56,6 +67,16 @@ def check_tables_exist():
     inspector = inspect(engine)
     tables = inspector.get_table_names()
     return len(tables) > 0
+
+
+def check_tables_empty():
+    table_classes = [TsunamiZone, LandslideZone, LiquefactionZone, SoftStoryProperty]
+    with SessionLocal() as session:
+        for table in table_classes:
+            count = session.query(table).count()
+            if count == 0:
+                return True
+    return False
 
 
 if __name__ == "__main__":

--- a/backend/database/init_db.py
+++ b/backend/database/init_db.py
@@ -69,8 +69,9 @@ def check_tables_exist():
     return len(tables) > 0
 
 
+# LandslideZone is not being used, and isn't included in this check.
 def check_tables_empty():
-    table_classes = [TsunamiZone, LandslideZone, LiquefactionZone, SoftStoryProperty]
+    table_classes = [TsunamiZone, LiquefactionZone, SoftStoryProperty]
     with SessionLocal() as session:
         for table in table_classes:
             count = session.query(table).count()

--- a/backend/database/init_db.py
+++ b/backend/database/init_db.py
@@ -11,7 +11,7 @@ Functions:
     drop_db(): Drops all tables defined in the SQLAlchemy `Base` 
                metadata. Use cautiously because this action is 
                irreversible.
-    check_tables_exist(): Checks if any tables exist in the database.
+    check_tables_exist(): Checks if all ETL-related tables exist in the database.
     check_tables_empty(): Checks if any main tables are empty.
 
 Usage:
@@ -63,21 +63,23 @@ def drop_db():
     print("Database tables dropped.")
 
 
+table_classes = [TsunamiZone, LiquefactionZone, SoftStoryProperty]
+
+
 def check_tables_exist():
     inspector = inspect(engine)
     tables = inspector.get_table_names()
-    return len(tables) > 0
+
+    for table in table_classes:
+        if table.__tablename__ not in tables:
+            return False
+    return True
 
 
 # LandslideZone is not being used, and isn't included in this check.
 def check_tables_empty():
-    table_classes = [TsunamiZone, LiquefactionZone, SoftStoryProperty]
-    inspector = inspect(engine)
-    tables = inspector.get_table_names()
-    for table in table_classes:
-        if table.__tablename__ not in tables:
-            return True
-        with SessionLocal() as session:
+    with SessionLocal() as session:
+        for table in table_classes:
             if session.query(table).first() is None:
                 return True
     return False

--- a/backend/database/init_db.py
+++ b/backend/database/init_db.py
@@ -74,8 +74,7 @@ def check_tables_empty():
     table_classes = [TsunamiZone, LiquefactionZone, SoftStoryProperty]
     with SessionLocal() as session:
         for table in table_classes:
-            count = session.query(table).count()
-            if count == 0:
+            if session.query(table).first() is None:
                 return True
     return False
 

--- a/backend/database/init_db.py
+++ b/backend/database/init_db.py
@@ -72,8 +72,12 @@ def check_tables_exist():
 # LandslideZone is not being used, and isn't included in this check.
 def check_tables_empty():
     table_classes = [TsunamiZone, LiquefactionZone, SoftStoryProperty]
-    with SessionLocal() as session:
-        for table in table_classes:
+    inspector = inspect(engine)
+    tables = inspector.get_table_names()
+    for table in table_classes:
+        if table.__tablename__ not in tables:
+            return True
+        with SessionLocal() as session:
             if session.query(table).first() is None:
                 return True
     return False

--- a/backend/etl/startup.sh
+++ b/backend/etl/startup.sh
@@ -34,15 +34,26 @@ if [[ $INIT_DB_EXIT_CODE -ne 0 ]]; then
     exit 1
 fi
 
-# Check for SKIP_ETL in the output
-ETL_SIGNAL=$(echo "$ETL_OUTPUT" | grep SKIP_ETL || true)
+# Check which tables need ETL
+ETL_TABLES=$(echo "$ETL_OUTPUT" | awk -F: '/^ETL_REQUIRED:/ {print $2}')
 
-# Run Python ETL scripts with diagnostics, unless SKIP_ETL is indicated
-if [[ "$ETL_SIGNAL" != "SKIP_ETL" ]]; then
-    run_python_script backend/etl/liquefaction_data_handler.py
-    run_python_script backend/etl/soft_story_properties_data_handler.py
-    run_python_script backend/etl/tsunami_data_handler.py
-fi
+# run ETL only for required tables
+for tbl in $ETL_TABLES; do
+  case "$tbl" in
+    tsunami_zones)
+      run_python_script backend/etl/tsunami_data_handler.py
+      ;;
+    liquefaction_zones)
+      run_python_script backend/etl/liquefaction_data_handler.py
+      ;;
+    soft_story_properties)
+      run_python_script backend/etl/soft_story_properties_data_handler.py
+      ;;
+    *)
+      echo "No ETL mapping for $tbl; skipping" >&2
+      ;;
+  esac
+done
 
 echo "===== startup.sh finished ====="
 

--- a/backend/etl/startup.sh
+++ b/backend/etl/startup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 set -x   # Trace each command as it executes
+set -o pipefail   # Fail if any command in a pipeline fails
 
 echo "===== Starting startup.sh ====="
 
@@ -24,11 +25,20 @@ run_python_script() {
     fi
 }
 
-# Run init_db.py and check for SKIP_ETL in its output
-ETL_SIGNAL=$($VENV_PYTHON backend/database/init_db.py | grep SKIP_ETL || true)
+# Run init_db.py
+ETL_OUTPUT=$($VENV_PYTHON backend/database/init_db.py)
+INIT_DB_EXIT_CODE=$?
+
+if [[ $INIT_DB_EXIT_CODE -ne 0 ]]; then
+    echo "init_db.py failed!"
+    exit 1
+fi
+
+# Check for SKIP_ETL in the output
+ETL_SIGNAL=$(echo "$ETL_OUTPUT" | grep SKIP_ETL || true)
 
 # Run Python ETL scripts with diagnostics, unless SKIP_ETL is indicated
-if [ "$ETL_SIGNAL" != "SKIP_ETL" ]; then
+if [[ "$ETL_SIGNAL" != "SKIP_ETL" ]]; then
     run_python_script backend/etl/liquefaction_data_handler.py
     run_python_script backend/etl/soft_story_properties_data_handler.py
     run_python_script backend/etl/tsunami_data_handler.py

--- a/backend/etl/startup.sh
+++ b/backend/etl/startup.sh
@@ -24,9 +24,8 @@ run_python_script() {
     fi
 }
 
-
 # Run init_db.py and check for SKIP_ETL in its output
-ETL_SIGNAL=$($VENV_PYTHON backend/database/init_db.py | grep SKIP_ETL)
+ETL_SIGNAL=$($VENV_PYTHON backend/database/init_db.py | grep SKIP_ETL || true)
 
 # Run Python ETL scripts with diagnostics, unless SKIP_ETL is indicated
 if [ "$ETL_SIGNAL" != "SKIP_ETL" ]; then

--- a/backend/etl/startup.sh
+++ b/backend/etl/startup.sh
@@ -24,11 +24,16 @@ run_python_script() {
     fi
 }
 
-# Run each Python script with diagnostics
-run_python_script backend/database/init_db.py
-run_python_script backend/etl/liquefaction_data_handler.py
-run_python_script backend/etl/soft_story_properties_data_handler.py
-run_python_script backend/etl/tsunami_data_handler.py
+
+# Run init_db.py and check for SKIP_ETL in its output
+ETL_SIGNAL=$($VENV_PYTHON backend/database/init_db.py | grep SKIP_ETL)
+
+# Run Python ETL scripts with diagnostics, unless SKIP_ETL is indicated
+if [ "$ETL_SIGNAL" != "SKIP_ETL" ]; then
+    run_python_script backend/etl/liquefaction_data_handler.py
+    run_python_script backend/etl/soft_story_properties_data_handler.py
+    run_python_script backend/etl/tsunami_data_handler.py
+fi
 
 echo "===== startup.sh finished ====="
 


### PR DESCRIPTION
# Description

Previously, every time the docker container would start up, it would re-create and re-populate backend data tables. This wasn't necessary because the data persists in the `db-data` volume, so re-setting it up is unnecessary and inefficient for most cases. This has been changed to:
* If tables don't exist, they are created and populated.
* If tables exist but any of them are empty, they are populated.
* If tables exist and are populated, ETL is skipped.

Closes #631

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

Start up with `docker compose up`. (This may need to be done twice, to ensure that the data tables are fully populated)

In the terminal console, look for lines that say:
`backend-1           | + ETL_SIGNAL=SKIP_ETL`                                                                                                               
`backend-1           | + '[' SKIP_ETL '!=' SKIP_ETL ']'`

This indicates that the ETL process was skipped, as the data tables already exist and are populated.

## Clean commits
- (X) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
