### PR TITLE
fix: Optimize GeoJSON creation and add type hints

### DIFF
--- a/backend/etl/tsunami_data_handler.py
+++ b/backend/etl/tsunami_data_handler.py
@@ -1,4 +1,5 @@
 from http.client import HTTPException
+from typing import List, Dict
 from backend.etl.data_handler import DataHandler
 from backend.api.models.tsunami import TsunamiZone
 from shapely.geometry import Polygon, MultiPolygon, mapping
@@ -24,7 +25,8 @@ class TsunamiDataHandler(DataHandler):
         """
         features = data["features"]
         parsed_data = []
-        geojson_features = []
+        geojson_features: List[Dict] = []
+        geojson = {"type": "FeatureCollection", "features": geojson_features}
 
         for feature in features:
             properties = feature.get("attributes", {})
@@ -71,7 +73,6 @@ class TsunamiDataHandler(DataHandler):
                 "properties": {"evacuate": tsunami_zone["evacuate"]},
             }
             geojson_features.append(geojson_feature)
-            geojson = {"type": "FeatureCollection", "features": geojson_features}
 
         return parsed_data, geojson
 

--- a/backend/etl/tsunami_data_handler.py
+++ b/backend/etl/tsunami_data_handler.py
@@ -1,8 +1,8 @@
 from http.client import HTTPException
-from typing import List, Dict
-from backend.etl.data_handler import DataHandler
-from backend.api.models.tsunami import TsunamiZone
+from typing import Any, Dict, List
 from shapely.geometry import Polygon, MultiPolygon, mapping
+from backend.api.models.tsunami import TsunamiZone
+from backend.etl.data_handler import DataHandler
 from geoalchemy2.shape import from_shape, to_shape
 
 TSUNAMI_URL = "https://services2.arcgis.com/zr3KAIbsRSUyARHG/ArcGIS/rest/services/CA_Tsunami_Hazard_Area/FeatureServer/0/query"

--- a/backend/etl/tsunami_data_handler.py
+++ b/backend/etl/tsunami_data_handler.py
@@ -25,8 +25,11 @@ class TsunamiDataHandler(DataHandler):
         """
         features = data["features"]
         parsed_data = []
-        geojson_features: List[Dict] = []
-        geojson = {"type": "FeatureCollection", "features": geojson_features}
+        geojson_features: List[Dict[str, Any]] = []
+        geojson: Dict[str, Any] = {
+            "type": "FeatureCollection",
+            "features": geojson_features,
+        }
 
         for feature in features:
             properties = feature.get("attributes", {})


### PR DESCRIPTION
# Description

This PR addresses two issues in `tsunami_data_handler.py`:
1.  It adds a `mypy` type hint to the `geojson_features` variable to resolve a static analysis error.
2.  It optimizes the creation of the GeoJSON `FeatureCollection` by moving its construction outside of the main processing loop, preventing it from being rebuilt on every iteration.

[Closes Issue #711 ](https://github.com/sfbrigade/datasci-earthquake/compare/bugfix/711/fix-indent-in-tsunami-data-handler-py?expand=1)

#711 

## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test

1.  Run the pre-commit hooks to confirm that the `mypy` check passes.
2.  Run the application locally and verify that the tsunami hazard layer on the map loads and displays correctly, confirming that the GeoJSON optimization did not introduce any regressions.

## Clean commits
- (x) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)