### PR TITLE
Fix: Validate GeoJson before writing in data_handler.py

### DIFF
--- a/backend/etl/data_handler.py
+++ b/backend/etl/data_handler.py
@@ -20,6 +20,8 @@ import logging
 from backend.etl.session_manager import SessionManager
 from backend.etl.request_handler import RequestHandler
 from sqlalchemy.exc import SQLAlchemyError, ProgrammingError, IntegrityError
+from geojson_pydantic import FeatureCollection
+from pydantic import ValidationError
 
 load_dotenv()
 
@@ -401,12 +403,16 @@ class DataHandler(ABC):
         Write the geojson file to the public/data folder. The geojson is a static asset that is displayed on the map in the app.
         """
         try:
+            FeatureCollection.model_validate(features)
             with open(geojson_path, "wt") as f:
                 json.dump(features, f)
 
             self.logger.info(
                 f"Generated {get_geojson_prefix()}{self.table.__name__}.geojson"
             )
+        except ValidationError as e:
+            self.logger.error(f"Failed to validate GeoJSON: {e}")
+            raise
         except Exception as e:
             self.logger.error(f"Failed to write GeoJSON: {e}")
             raise

--- a/backend/etl/tests/test_data_handler.py
+++ b/backend/etl/tests/test_data_handler.py
@@ -522,7 +522,10 @@ def test_update_last_export_time_in_db(test_db):
 def test_save_geojson_file(tmp_path):
     """Test that geojsons are saved"""
     data_handler = DummyDataHandler(url="", table=DummyModel)
-    features = {"type": "FeatureCollection", "features": [{"id": 1}]}
+    features = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": None, "properties": {"id": 1}}],
+    }
 
     # Create a path where the geojson is going to be saved
     geojson_path = tmp_path / "test.geojson"

--- a/backend/etl/tests/test_data_handler.py
+++ b/backend/etl/tests/test_data_handler.py
@@ -31,6 +31,8 @@ from backend.etl.soft_story_properties_data_handler import (
 import os
 import json
 from pathlib import Path
+from pydantic import ValidationError
+from geojson_pydantic import FeatureCollection
 
 
 class DummyModel(Base):
@@ -612,3 +614,53 @@ def test_export_geojson_if_changed_on_prod_data_not_changed(tmp_path, monkeypatc
                     data_handler.export_geojson_if_changed(features)
                     mock_save.assert_not_called()
                     mock_update.assert_not_called()
+
+
+def test_save_geojson_file_raises_validation_error_for_invalid_geojson(
+    data_handler, tmp_path
+):
+    """
+    Test that _save_geojson_file raises a ValidationError when the input is not a valid GeoJSON FeatureCollection.
+    """
+    invalid_geojson = {"type": "NotAFeatureCollection", "features": []}
+    geojson_path = tmp_path / "test.geojson"
+
+    with pytest.raises(ValidationError):
+        data_handler._save_geojson_file(invalid_geojson, geojson_path)
+
+    # Also assert that the file was not created
+    assert not geojson_path.exists()
+
+
+def test_save_geojson_file_writes_valid_geojson(data_handler, tmp_path):
+    """
+    Test that _save_geojson_file successfully writes a valid GeoJSON FeatureCollection.
+    """
+    valid_geojson = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": None, "properties": {}}],
+    }
+    geojson_path = tmp_path / "test.geojson"
+
+    # This should not raise an exception
+    data_handler._save_geojson_file(valid_geojson, geojson_path)
+
+    # Assert that the file was created and has the correct content
+    assert geojson_path.exists()
+    with open(geojson_path) as f:
+        data = json.load(f)
+    assert data == valid_geojson
+
+
+def test_save_geojson_file_logs_validation_error(data_handler, tmp_path, caplog):
+    """
+    Test that a validation error is logged when saving invalid GeoJSON.
+    """
+    invalid_geojson = {"type": "Invalid", "features": "not a list"}
+    geojson_path = tmp_path / "test.geojson"
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(ValidationError):
+            data_handler._save_geojson_file(invalid_geojson, geojson_path)
+
+    assert "Failed to validate GeoJSON" in caplog.text

--- a/backend/etl/tests/test_data_handler.py
+++ b/backend/etl/tests/test_data_handler.py
@@ -236,9 +236,9 @@ def test_fetch_data_partial_page(data_handler, caplog):
     full_page_response.json.return_value = {
         "type": "FeatureCollection",
         "features": [
-            {"id": 0},
-            {"id": 1},
-            {"id": 2},
+            {"type": "Feature", "geometry": None, "properties": {"id": 0}},
+            {"type": "Feature", "geometry": None, "properties": {"id": 1}},
+            {"type": "Feature", "geometry": None, "properties": {"id": 2}},
         ],
     }
     full_page_response.status_code = 200
@@ -248,8 +248,8 @@ def test_fetch_data_partial_page(data_handler, caplog):
     partial_page_response.json.return_value = {
         "type": "FeatureCollection",
         "features": [
-            {"id": 3},
-            {"id": 4},
+            {"type": "Feature", "geometry": None, "properties": {"id": 3}},
+            {"type": "Feature", "geometry": None, "properties": {"id": 4}},
         ],
     }
     partial_page_response.status_code = 200
@@ -270,8 +270,8 @@ def test_fetch_data_partial_page(data_handler, caplog):
     calls = data_handler.session.get.call_args_list
     assert calls[0][1]["params"] == {"$offset": 0, "$limit": 3}
     assert calls[1][1]["params"] == {"$offset": 3, "$limit": 3}
-    assert result["features"][0]["id"] == 0
-    assert result["features"][-1]["id"] == 4
+    assert result["features"][0]["properties"]["id"] == 0
+    assert result["features"][-1]["properties"]["id"] == 4
     assert "Assuming final page and stopping fetch" in caplog.text
 
 
@@ -541,7 +541,10 @@ def test_export_geojson_if_changed_local_file_exists(tmp_path, monkeypatch):
     monkeypatch.setenv("ENVIRONMENT", "local")
     monkeypatch.setenv("DATA_GEOJSON_PATH", str(tmp_path) + "/")
     data_handler = DummyDataHandler(url="", table=DummyModel)
-    features = {"type": "FeatureCollection", "features": [{"id": 1}]}
+    features = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": None, "properties": {"id": 1}}],
+    }
 
     # Create a file to simulate the scenario when it already exists
     geojson_path = tmp_path / "DummyModel.geojson"
@@ -559,7 +562,10 @@ def test_export_geojson_if_changed_local_file_not_exists(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_GEOJSON_PATH", str(tmp_path) + "/")
 
     data_handler = DummyDataHandler(url="", table=DummyModel)
-    features = {"type": "FeatureCollection", "features": [{"id": 1}]}
+    features = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": None, "properties": {"id": 1}}],
+    }
 
     # Ensure file doesn't exist
     geojson_path = tmp_path / "DummyModel.geojson"
@@ -574,7 +580,10 @@ def test_export_geojson_if_changed_local_file_not_exists(tmp_path, monkeypatch):
 def test_export_geojson_if_changed_on_prod_data_changed(tmp_path, monkeypatch):
     """Test production environment when geojson data is stale and needs to be updated"""
     data_handler = DummyDataHandler(url="", table=DummyModel)
-    features = {"type": "FeatureCollection", "features": [{"id": 1}]}
+    features = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": None, "properties": {"id": 1}}],
+    }
     monkeypatch.setenv("ENVIRONMENT", "prod")
 
     # Patch methods to simulate data changed
@@ -598,7 +607,10 @@ def test_export_geojson_if_changed_on_prod_data_changed(tmp_path, monkeypatch):
 def test_export_geojson_if_changed_on_prod_data_not_changed(tmp_path, monkeypatch):
     """Test production environment when geojson data is up-to-date"""
     data_handler = DummyDataHandler(url="", table=DummyModel)
-    features = {"type": "FeatureCollection", "features": [{"id": 1}]}
+    features = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": None, "properties": {"id": 1}}],
+    }
     monkeypatch.setenv("ENVIRONMENT", "prod")
 
     # Patch methods to simulate data did not change


### PR DESCRIPTION
# Description

This PR adds GeoJSON validation to the `_save_geojson_file` method in `data_handler.py` to ensure that only valid GeoJSON files are written to disk. This prevents invalid files from breaking the frontend.

The validation is performed using the `geojson-pydantic` library, as specified in the issue. Validation errors are logged and raise exceptions to prevent writing invalid files.

Additionally, I updated the tests in `test_data_handler.py` to accommodate the new validation logic and to improve the overall test coverage for the data handler.

Fixes #712

## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- (x) I added automated tests
- ( ) I think tests are unnecessary

## How to test

1. Run the ETL scripts.
2. Verify that the GeoJSON files are created in the `public/data` directory.
3. Run the tests in backend/etl/tests/test_data_handler.py to verify that validation works correctly (tests already exist that verify invalid files aren't saved).

## Clean commits
- (x) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)