### PR TITLE
Use actions variable for node version in ci and e2e_tests workflows.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: ${{ vars.NODE_VERSION }}
 
       - name: Install Node.js dependencies
         run: npm ci
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.x'  
+          node-version: ${{ vars.NODE_VERSION }}  
       - name: Install dependencies
         run: npm ci 
       - name: Check Next.js production build

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -28,7 +28,7 @@ jobs:
         
     - uses: actions/setup-node@v3
       with:
-        node-version: '20.x'
+        node-version: ${{ vars.NODE_VERSION }}
         
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
# Description

A shared [actions repo variable](https://github.com/sfbrigade/datasci-earthquake/settings/variables/actions) for `NODE_VERSION` was created that can be used across workflows. This PR replaces hard coded node versions with the variable.

- Closes https://github.com/sfbrigade/datasci-earthquake/issues/760

## Type of changes
- ( ) Bugfix
- (x) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test

You can see that the CI checks that use this variable(`eslint`, `nextjs_build_check`, `e2e-tests`) are passing below.

## Clean commits
- (x) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
