### PR TITLE
Fix/762/backend healthcheck timeout

### DIFF
--- a/backend/etl/parallel_etl.py
+++ b/backend/etl/parallel_etl.py
@@ -1,0 +1,264 @@
+"""
+Parallel ETL orchestration system.
+
+Provides functionality to run multiple ETL processes concurrently
+with error handling, timeout protection, and result tracking.
+"""
+
+import logging
+from typing import Dict, List, Optional
+from datetime import datetime
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    as_completed,
+    TimeoutError as FuturesTimeoutError,
+)
+
+from backend.etl.parallel_etl_types import (
+    ETLCallable,
+    ETLResult,
+    ParallelETLResult,
+    ETLStatus,
+    ETLExecutionError,
+    ETLTimeoutError,
+    ETLValidationError,
+)
+
+# Configure module logger
+logger = logging.getLogger(__name__)
+
+# Safety limits
+MAX_CONCURRENT_ETLS = 3
+DEFAULT_TIMEOUT_SECONDS = 180  # 3 minutes per ETL
+
+
+def run_single_etl(
+    name: str,
+    etl_func: ETLCallable,
+    timeout: int = DEFAULT_TIMEOUT_SECONDS,
+    run_id: Optional[str] = None,
+) -> ETLResult:
+    """
+    Execute a single ETL process with error handling and timeout protection.
+
+    Args:
+        name: ETL identifier
+        etl_func: Callable that performs the ETL
+        timeout: Maximum seconds before timeout
+        run_id: Optional correlation ID for logging
+
+    Returns:
+        ETLResult with success/failure status and metrics
+    """
+    # Input validation
+    if not name or not name.strip():
+        raise ETLValidationError("ETL name cannot be empty or whitespace")
+
+    if etl_func is None:
+        raise ETLValidationError("ETL function cannot be None")
+
+    if not callable(etl_func):
+        raise ETLValidationError(f"ETL function must be callable, got {type(etl_func)}")
+
+    if timeout <= 0:
+        raise ETLValidationError(f"Timeout must be positive, got {timeout}")
+
+    # Prepare logging context
+    log_prefix = (
+        f"[PARALLEL_ETL] [run_id={run_id}] [{name}]"
+        if run_id
+        else f"[PARALLEL_ETL] [{name}]"
+    )
+
+    start_time = datetime.now()
+    logger.info(f"{log_prefix} Starting ETL execution (timeout={timeout}s)")
+
+    try:
+        # Execute with timeout using ThreadPoolExecutor
+        # (Note: Python threading has GIL limitations, but ETL is I/O bound)
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(etl_func)
+            try:
+                # Wait for completion or timeout
+                future.result(timeout=timeout)
+
+                # Success!
+                end_time = datetime.now()
+                duration = (end_time - start_time).total_seconds()
+
+                logger.info(f"{log_prefix} Completed successfully in {duration:.2f}s")
+
+                return ETLResult(
+                    name=name,
+                    status=ETLStatus.SUCCESS,
+                    duration_seconds=duration,
+                    start_time=start_time,
+                    end_time=end_time,
+                )
+
+            except FuturesTimeoutError:
+                # ETL exceeded timeout
+                end_time = datetime.now()
+                duration = (end_time - start_time).total_seconds()
+
+                timeout_error = ETLTimeoutError(name, timeout)
+                logger.error(f"{log_prefix} Timeout after {duration:.2f}s")
+
+                return ETLResult(
+                    name=name,
+                    status=ETLStatus.TIMEOUT,
+                    duration_seconds=duration,
+                    start_time=start_time,
+                    end_time=end_time,
+                    error=timeout_error,
+                )
+
+    except Exception as e:
+        # ETL raised an exception
+        end_time = datetime.now()
+        duration = (end_time - start_time).total_seconds()
+
+        execution_error = ETLExecutionError(name, e)
+        logger.error(
+            f"{log_prefix} Failed after {duration:.2f}s: {type(e).__name__}: {e}",
+            exc_info=True,
+        )
+
+        return ETLResult(
+            name=name,
+            status=ETLStatus.FAILED,
+            duration_seconds=duration,
+            start_time=start_time,
+            end_time=end_time,
+            error=execution_error,
+        )
+
+
+def run_parallel_etls(
+    etl_map: Dict[str, ETLCallable],
+    timeout_per_etl: int = DEFAULT_TIMEOUT_SECONDS,
+    max_workers: int = MAX_CONCURRENT_ETLS,
+    run_id: Optional[str] = None,
+) -> ParallelETLResult:
+    """
+    Execute multiple ETL processes concurrently.
+
+    This is the main orchestration function. It:
+    - Validates all inputs before starting
+    - Executes ETLs in parallel using thread pool
+    - Collects all results (success and failure)
+    - Returns aggregate metrics
+    - Never crashes - always returns a result
+
+    Args:
+        etl_map: Dict mapping ETL name to callable
+        timeout_per_etl: Max seconds per individual ETL
+        max_workers: Maximum concurrent ETL processes
+        run_id: Optional correlation ID for logging
+
+    Returns:
+        ParallelETLResult with all individual results and aggregate metrics
+
+    Raises:
+        ETLValidationError: If inputs are invalid (before any execution)
+
+    Notes:
+        - If ANY ETL fails, the aggregate result marks overall failure
+        - But ALL ETLs complete (we don't cancel others on failure)
+        - This allows maximum data collection and debugging
+    """
+    # Input validation
+    if not etl_map:
+        raise ETLValidationError("ETL map cannot be empty")
+
+    if timeout_per_etl <= 0:
+        raise ETLValidationError(f"Timeout must be positive, got {timeout_per_etl}")
+
+    if max_workers <= 0:
+        raise ETLValidationError(f"Max workers must be positive, got {max_workers}")
+
+    # Validate all ETL names and callables upfront
+    for name, func in etl_map.items():
+        if not name or not name.strip():
+            raise ETLValidationError("All ETL names must be non-empty")
+        if not callable(func):
+            raise ETLValidationError(f"ETL '{name}' function is not callable")
+
+    # Prepare for execution
+    num_etls = len(etl_map)
+    log_prefix = f"[PARALLEL_ETL] [run_id={run_id}]" if run_id else "[PARALLEL_ETL]"
+
+    logger.info(
+        f"{log_prefix} Starting {num_etls} ETL processes in parallel "
+        f"(max_workers={max_workers}, timeout_per_etl={timeout_per_etl}s)"
+    )
+
+    overall_start = datetime.now()
+    results: List[ETLResult] = []
+
+    # Execute in parallel
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Submit all ETL jobs
+        future_to_name = {
+            executor.submit(run_single_etl, name, func, timeout_per_etl, run_id): name
+            for name, func in etl_map.items()
+        }
+
+        # Collect results as they complete
+        for future in as_completed(future_to_name):
+            etl_name = future_to_name[future]
+            try:
+                result = future.result()  # Get the ETLResult
+                results.append(result)
+
+                if result.is_successful:
+                    logger.info(f"{log_prefix} [{etl_name}] ✓ Completed")
+                else:
+                    logger.error(f"{log_prefix} [{etl_name}] ✗ Failed: {result.error}")
+
+            except Exception as e:
+                # This should never happen (run_single_etl catches everything)
+                # But defensive programming: handle it anyway
+                logger.error(
+                    f"{log_prefix} [{etl_name}] Unexpected error in orchestration: {e}",
+                    exc_info=True,
+                )
+
+                # Create a failure result
+                end_time = datetime.now()
+                duration = (end_time - overall_start).total_seconds()
+                results.append(
+                    ETLResult(
+                        name=etl_name,
+                        status=ETLStatus.FAILED,
+                        duration_seconds=duration,
+                        start_time=overall_start,
+                        end_time=end_time,
+                        error=ETLExecutionError(etl_name, e),
+                    )
+                )
+
+    # Calculate aggregate metrics
+    overall_end = datetime.now()
+    total_duration = (overall_end - overall_start).total_seconds()
+
+    aggregate = ParallelETLResult(
+        results=tuple(results),
+        total_duration_seconds=total_duration,
+        start_time=overall_start,
+        end_time=overall_end,
+    )
+
+    # Log summary
+    if aggregate.all_successful:
+        logger.info(
+            f"{log_prefix} ✓ All {num_etls} ETLs succeeded in {total_duration:.2f}s "
+        )
+    else:
+        failed = [r.name for r in aggregate.failed_etls]
+        logger.error(
+            f"{log_prefix} ✗ {len(failed)}/{num_etls} ETLs failed in {total_duration:.2f}s. "
+            f"Failed: {', '.join(failed)}"
+        )
+
+    return aggregate

--- a/backend/etl/parallel_etl_types.py
+++ b/backend/etl/parallel_etl_types.py
@@ -1,0 +1,196 @@
+"""
+Type definitions and error classes for parallel ETL system.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Callable
+from datetime import datetime
+from enum import Enum
+
+
+class ETLStatus(Enum):
+    """Status of an ETL execution"""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+    SKIPPED = "skipped"
+
+
+class ParallelETLError(Exception):
+    """Base exception for parallel ETL system"""
+
+    pass
+
+
+class ETLExecutionError(ParallelETLError):
+    """Wraps errors from individual ETL execution with context"""
+
+    def __init__(self, etl_name: str, original_error: Exception):
+        if not etl_name:
+            raise ValueError("ETL name cannot be empty")
+        if original_error is None:
+            raise ValueError("Original error cannot be None")
+
+        self.etl_name = etl_name
+        self.original_error = original_error
+        super().__init__(
+            f"ETL '{etl_name}' failed: {type(original_error).__name__}: {original_error}"
+        )
+
+
+class ETLTimeoutError(ParallelETLError):
+    """ETL exceeded time limit"""
+
+    def __init__(self, etl_name: str, timeout_seconds: int):
+        if not etl_name:
+            raise ValueError("ETL name cannot be empty")
+        if timeout_seconds <= 0:
+            raise ValueError("Timeout must be positive")
+
+        self.etl_name = etl_name
+        self.timeout_seconds = timeout_seconds
+        super().__init__(
+            f"ETL '{etl_name}' exceeded timeout of {timeout_seconds} seconds"
+        )
+
+
+class ETLValidationError(ParallelETLError):
+    """Invalid input to ETL system"""
+
+    pass
+
+
+@dataclass(frozen=True)
+class ETLResult:
+    """
+    Immutable result of a single ETL execution.
+
+    Attributes:
+        name: ETL identifier
+        status: Execution outcome
+        duration_seconds: Time taken to complete
+        start_time: Execution start time
+        end_time: Execution end time
+        error: Exception if failed, None if successful
+        records_processed: Number of records processed
+    """
+
+    name: str
+    status: ETLStatus
+    duration_seconds: float
+    start_time: datetime
+    end_time: datetime
+    error: Optional[Exception] = None
+    records_processed: Optional[int] = None
+
+    def __post_init__(self):
+        """Validate result invariants"""
+        if not self.name or not self.name.strip():
+            raise ValueError("ETL name cannot be empty or whitespace")
+
+        if self.duration_seconds < 0:
+            raise ValueError(f"Duration cannot be negative: {self.duration_seconds}")
+
+        if self.end_time < self.start_time:
+            raise ValueError(
+                f"End time ({self.end_time}) cannot be before start time ({self.start_time})"
+            )
+
+        # Verify duration matches timestamps (with small tolerance for floating point)
+        actual_duration = (self.end_time - self.start_time).total_seconds()
+        if abs(actual_duration - self.duration_seconds) > 0.1:  # 100ms tolerance
+            raise ValueError(
+                f"Duration ({self.duration_seconds}s) doesn't match "
+                f"timestamps ({actual_duration}s)"
+            )
+
+        if self.records_processed is not None and self.records_processed < 0:
+            raise ValueError(
+                f"Records processed cannot be negative: {self.records_processed}"
+            )
+
+        # Status-error consistency
+        if self.status == ETLStatus.SUCCESS and self.error is not None:
+            raise ValueError("Successful ETL result cannot have an error")
+
+        if self.status == ETLStatus.FAILED and self.error is None:
+            raise ValueError("Failed ETL result must have an error")
+
+    @property
+    def is_successful(self) -> bool:
+        """Convenience property for checking success"""
+        return self.status == ETLStatus.SUCCESS
+
+    def __str__(self) -> str:
+        """Human-readable representation"""
+        if self.is_successful:
+            records = (
+                f", {self.records_processed} records" if self.records_processed else ""
+            )
+            return (
+                f"ETL '{self.name}': SUCCESS in {self.duration_seconds:.2f}s{records}"
+            )
+        else:
+            error_msg = f": {self.error}" if self.error else ""
+            return f"ETL '{self.name}': {self.status.value.upper()} in {self.duration_seconds:.2f}s{error_msg}"
+
+
+@dataclass(frozen=True)
+class ParallelETLResult:
+    """
+    Immutable result of parallel ETL execution.
+
+    Aggregates results from all ETL processes.
+
+    Attributes:
+        results: List of individual ETL results
+        total_duration_seconds: Wall-clock time for all ETLs
+        start_time: When parallel execution began
+        end_time: When parallel execution completed
+    """
+
+    results: tuple[ETLResult, ...]  # Tuple for immutability
+    total_duration_seconds: float
+    start_time: datetime
+    end_time: datetime
+
+    def __post_init__(self):
+        """Validate aggregate result invariants"""
+        if self.total_duration_seconds < 0:
+            raise ValueError("Total duration cannot be negative")
+
+        if self.end_time < self.start_time:
+            raise ValueError("End time cannot be before start time")
+
+        # Verify at least one result
+        if not self.results:
+            raise ValueError("Must have at least one ETL result")
+
+    @property
+    def all_successful(self) -> bool:
+        """True if all ETLs succeeded"""
+        return all(r.is_successful for r in self.results)
+
+    @property
+    def failed_etls(self) -> tuple[ETLResult, ...]:
+        """Get list of failed ETL results"""
+        return tuple(r for r in self.results if not r.is_successful)
+
+    @property
+    def success_count(self) -> int:
+        """Number of successful ETLs"""
+        return sum(1 for r in self.results if r.is_successful)
+
+    def __str__(self) -> str:
+        """Human-readable summary"""
+        status = "SUCCESS" if self.all_successful else "FAILED"
+        return (
+            f"Parallel ETL: {status} - "
+            f"{self.success_count}/{len(self.results)} succeeded in "
+            f"{self.total_duration_seconds:.2f}s"
+        )
+
+
+# Type alias for ETL callable
+ETLCallable = Callable[[], None]

--- a/backend/etl/run_parallel_etls.py
+++ b/backend/etl/run_parallel_etls.py
@@ -1,0 +1,173 @@
+"""
+Parallel ETL runner for production use.
+
+This script orchestrates the execution of all ETL processes in parallel,
+integrating with the existing ETL handler implementations.
+
+Usage:
+    python backend/etl/run_parallel_etls.py table1 table2 table3
+
+Example:
+    python backend/etl/run_parallel_etls.py tsunami_zones liquefaction_zones soft_story_properties
+"""
+
+import sys
+import logging
+import os
+from typing import Dict
+from http.client import HTTPException
+
+from backend.etl.parallel_etl import run_parallel_etls
+from backend.etl.parallel_etl_types import ETLCallable, ParallelETLResult
+
+# Import individual ETL handlers
+from backend.etl.tsunami_data_handler import TsunamiDataHandler, TSUNAMI_URL
+from backend.etl.liquefaction_data_handler import (
+    _LiquefactionDataHandler,
+    _LIQUEFACTION_URL,
+)
+from backend.etl.soft_story_properties_data_handler import (
+    _SoftStoryPropertiesDataHandler,
+    _SOFT_STORY_PROPERTIES_URL,
+)
+from backend.api.models.tsunami import TsunamiZone
+from backend.api.models.liquefaction_zones import LiquefactionZone
+from backend.api.models.soft_story_properties import SoftStoryProperty
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    force=True,
+)
+logger = logging.getLogger(__name__)
+
+
+def run_tsunami_etl():
+    """Execute tsunami ETL process"""
+    handler = TsunamiDataHandler(TSUNAMI_URL, TsunamiZone)
+    try:
+        params = {
+            "where": "County='San Francisco' AND Evacuate='Yes, Tsunami Hazard Area'",
+            "outFields": "*",
+            "f": "json",
+        }
+        data = handler.fetch_data(params)
+        parsed, geojson = handler.parse_data(data)
+        handler.export_geojson_if_changed(geojson)
+        handler.bulk_insert_data(parsed, "identifier")
+        logger.info(f"Tsunami ETL completed: {len(parsed)} records")
+    except HTTPException as e:
+        logger.error(f"Tsunami ETL failed: {e}")
+        raise
+
+
+def run_liquefaction_etl():
+    """Execute liquefaction ETL process"""
+    handler = _LiquefactionDataHandler(_LIQUEFACTION_URL, LiquefactionZone)
+    try:
+        data = handler.fetch_data()
+        parsed, geojson = handler.parse_data(data)
+        handler.export_geojson_if_changed(geojson)
+        handler.bulk_insert_data(parsed, "identifier")
+        logger.info(f"Liquefaction ETL completed: {len(parsed)} records")
+    except HTTPException as e:
+        logger.error(f"Liquefaction ETL failed: {e}")
+        raise
+
+
+def run_soft_story_etl():
+    """Execute soft story properties ETL process"""
+    mapbox_api_key = os.environ.get("NEXT_PUBLIC_MAPBOX_TOKEN", "")
+    handler = _SoftStoryPropertiesDataHandler(
+        _SOFT_STORY_PROPERTIES_URL, SoftStoryProperty, mapbox_api_key
+    )
+    try:
+        data = handler.fetch_data()
+        parsed, geojson = handler.parse_data(data)
+        handler.export_geojson_if_changed(geojson)
+        handler.bulk_insert_data(parsed, "address")
+        logger.info(f"Soft Story ETL completed: {len(parsed)} records")
+    except HTTPException as e:
+        logger.error(f"Soft Story ETL failed: {e}")
+        raise
+
+
+# Map table names to ETL functions
+ETL_REGISTRY: Dict[str, ETLCallable] = {
+    "tsunami_zones": run_tsunami_etl,
+    "liquefaction_zones": run_liquefaction_etl,
+    "soft_story_properties": run_soft_story_etl,
+}
+
+
+def main(table_names: list[str]) -> int:
+    """
+    Main entry point for parallel ETL execution.
+
+    Args:
+        table_names: List of table names requiring ETL
+
+    Returns:
+        0 if all ETLs succeeded, 1 if any failed
+    """
+    if not table_names:
+        logger.info("No ETL processes needed")
+        return 0
+
+    # Filter to only requested tables
+    etls_to_run = {
+        name: func for name, func in ETL_REGISTRY.items() if name in table_names
+    }
+
+    if not etls_to_run:
+        logger.warning(f"No matching ETLs found for tables: {table_names}")
+        return 0
+
+    logger.info(f"=" * 80)
+    logger.info(f"Running {len(etls_to_run)} ETL processes in parallel")
+    logger.info(f"Tables: {', '.join(etls_to_run.keys())}")
+    logger.info(f"=" * 80)
+
+    try:
+        # Run ETLs in parallel
+        result: ParallelETLResult = run_parallel_etls(etls_to_run)
+
+        # Log summary
+        logger.info(f"=" * 80)
+        logger.info(f"PARALLEL ETL SUMMARY")
+        logger.info(f"=" * 80)
+        logger.info(f"Total time: {result.total_duration_seconds:.2f}s")
+        logger.info(f"Success: {result.success_count}/{len(result.results)}")
+
+        # Log individual results
+        for etl_result in result.results:
+            status_symbol = "✓" if etl_result.is_successful else "✗"
+            logger.info(
+                f"  {status_symbol} {etl_result.name}: "
+                f"{etl_result.status.value} in {etl_result.duration_seconds:.2f}s"
+            )
+
+        logger.info(f"=" * 80)
+
+        # Exit with appropriate code
+        if result.all_successful:
+            logger.info("All ETL processes completed successfully")
+            return 0
+        else:
+            logger.error("Some ETL processes failed")
+            # Log failure details
+            for failed in result.failed_etls:
+                logger.error(f"  {failed.name}: {failed.error}")
+            return 1
+
+    except Exception as e:
+        logger.error(f"Fatal error in parallel ETL execution: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    # Get table names from command line arguments
+    tables = sys.argv[1:] if len(sys.argv) > 1 else []
+    exit_code = main(tables)
+    sys.exit(exit_code)

--- a/backend/etl/startup.sh
+++ b/backend/etl/startup.sh
@@ -37,23 +37,16 @@ fi
 # Check which tables need ETL
 ETL_TABLES=$(echo "$ETL_OUTPUT" | awk -F: '/^ETL_REQUIRED:/ {print $2}')
 
-# run ETL only for required tables
-for tbl in $ETL_TABLES; do
-  case "$tbl" in
-    tsunami_zones)
-      run_python_script backend/etl/tsunami_data_handler.py
-      ;;
-    liquefaction_zones)
-      run_python_script backend/etl/liquefaction_data_handler.py
-      ;;
-    soft_story_properties)
-      run_python_script backend/etl/soft_story_properties_data_handler.py
-      ;;
-    *)
-      echo "No ETL mapping for $tbl; skipping" >&2
-      ;;
-  esac
-done
+# Run ETL processes in parallel if any are needed
+if [ -n "$ETL_TABLES" ]; then
+    echo "Running ETL processes in parallel..."
+    if ! "$VENV_PYTHON" backend/etl/run_parallel_etls.py $ETL_TABLES; then
+        echo "Parallel ETL execution failed" >&2
+        exit 1
+    fi
+else
+    echo "No ETL processes needed - all tables are populated"
+fi
 
 echo "===== startup.sh finished ====="
 

--- a/backend/etl/tests/test_parallel_etl.py
+++ b/backend/etl/tests/test_parallel_etl.py
@@ -1,0 +1,527 @@
+"""
+Unit tests for parallel ETL orchestration.
+
+Following TDD principles - these tests are written BEFORE implementation.
+Tests use mocks to isolate the orchestration logic from actual ETL execution.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, call
+from datetime import datetime, timedelta
+import time
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+from backend.etl.parallel_etl_types import (
+    ETLStatus,
+    ETLResult,
+    ParallelETLResult,
+    ETLExecutionError,
+    ETLTimeoutError,
+    ETLValidationError,
+)
+from backend.etl.parallel_etl import run_single_etl, run_parallel_etls
+
+
+class TestETLResult:
+    """Test the ETLResult dataclass validation"""
+
+    def test_create_successful_result(self):
+        """Should create a valid successful result"""
+        start = datetime.now()
+        end = start + timedelta(seconds=5)
+
+        result = ETLResult(
+            name="test_etl",
+            status=ETLStatus.SUCCESS,
+            duration_seconds=5.0,
+            start_time=start,
+            end_time=end,
+            records_processed=100,
+        )
+
+        assert result.name == "test_etl"
+        assert result.is_successful
+        assert result.records_processed == 100
+
+    def test_create_failed_result(self):
+        """Should create a valid failed result with error"""
+        start = datetime.now()
+        end = start + timedelta(seconds=3)
+        error = ValueError("Test error")
+
+        result = ETLResult(
+            name="test_etl",
+            status=ETLStatus.FAILED,
+            duration_seconds=3.0,
+            start_time=start,
+            end_time=end,
+            error=error,
+        )
+
+        assert not result.is_successful
+        assert result.error == error
+
+    def test_reject_empty_name(self):
+        """Should reject empty ETL name"""
+        start = datetime.now()
+        end = start + timedelta(seconds=1)
+
+        with pytest.raises(ValueError, match="name cannot be empty"):
+            ETLResult(
+                name="",
+                status=ETLStatus.SUCCESS,
+                duration_seconds=1.0,
+                start_time=start,
+                end_time=end,
+            )
+
+    def test_reject_whitespace_name(self):
+        """Should reject whitespace-only ETL name"""
+        start = datetime.now()
+        end = start + timedelta(seconds=1)
+
+        with pytest.raises(ValueError, match="name cannot be empty"):
+            ETLResult(
+                name="   ",
+                status=ETLStatus.SUCCESS,
+                duration_seconds=1.0,
+                start_time=start,
+                end_time=end,
+            )
+
+    def test_reject_negative_duration(self):
+        """Should reject negative duration"""
+        start = datetime.now()
+        end = start + timedelta(seconds=1)
+
+        with pytest.raises(ValueError, match="Duration cannot be negative"):
+            ETLResult(
+                name="test",
+                status=ETLStatus.SUCCESS,
+                duration_seconds=-1.0,
+                start_time=start,
+                end_time=end,
+            )
+
+    def test_reject_end_before_start(self):
+        """Should reject end time before start time"""
+        start = datetime.now()
+        end = start - timedelta(seconds=1)
+
+        with pytest.raises(ValueError, match="End time.*cannot be before start time"):
+            ETLResult(
+                name="test",
+                status=ETLStatus.SUCCESS,
+                duration_seconds=1.0,  # Will also fail consistency check
+                start_time=start,
+                end_time=end,
+            )
+
+    def test_reject_duration_timestamp_mismatch(self):
+        """Should reject if duration doesn't match timestamps"""
+        start = datetime.now()
+        end = start + timedelta(seconds=5)
+
+        with pytest.raises(ValueError, match="Duration.*doesn't match"):
+            ETLResult(
+                name="test",
+                status=ETLStatus.SUCCESS,
+                duration_seconds=10.0,  # Doesn't match 5 second difference
+                start_time=start,
+                end_time=end,
+            )
+
+    def test_reject_negative_records(self):
+        """Should reject negative record count"""
+        start = datetime.now()
+        end = start + timedelta(seconds=1)
+
+        with pytest.raises(ValueError, match="Records processed cannot be negative"):
+            ETLResult(
+                name="test",
+                status=ETLStatus.SUCCESS,
+                duration_seconds=1.0,
+                start_time=start,
+                end_time=end,
+                records_processed=-5,
+            )
+
+    def test_reject_success_with_error(self):
+        """Should reject successful result that has an error"""
+        start = datetime.now()
+        end = start + timedelta(seconds=1)
+
+        with pytest.raises(ValueError, match="Successful.*cannot have an error"):
+            ETLResult(
+                name="test",
+                status=ETLStatus.SUCCESS,
+                duration_seconds=1.0,
+                start_time=start,
+                end_time=end,
+                error=ValueError("Shouldn't be here"),
+            )
+
+    def test_reject_failed_without_error(self):
+        """Should reject failed result without an error"""
+        start = datetime.now()
+        end = start + timedelta(seconds=1)
+
+        with pytest.raises(ValueError, match="Failed.*must have an error"):
+            ETLResult(
+                name="test",
+                status=ETLStatus.FAILED,
+                duration_seconds=1.0,
+                start_time=start,
+                end_time=end,
+                error=None,
+            )
+
+
+class TestParallelETLResult:
+    """Test the ParallelETLResult aggregate"""
+
+    def test_create_successful_aggregate(self):
+        """Should create valid aggregate result"""
+        start = datetime.now()
+
+        result1 = ETLResult(
+            name="etl1",
+            status=ETLStatus.SUCCESS,
+            duration_seconds=5.0,
+            start_time=start,
+            end_time=start + timedelta(seconds=5),
+        )
+
+        result2 = ETLResult(
+            name="etl2",
+            status=ETLStatus.SUCCESS,
+            duration_seconds=3.0,
+            start_time=start,
+            end_time=start + timedelta(seconds=3),
+        )
+
+        aggregate = ParallelETLResult(
+            results=(result1, result2),
+            total_duration_seconds=5.0,  # Wall clock (parallel)
+            start_time=start,
+            end_time=start + timedelta(seconds=5),
+        )
+
+        assert aggregate.all_successful
+        assert aggregate.success_count == 2
+        assert len(aggregate.failed_etls) == 0
+
+    def test_aggregate_with_failures(self):
+        """Should track failed ETLs"""
+        start = datetime.now()
+
+        result1 = ETLResult(
+            name="etl1",
+            status=ETLStatus.SUCCESS,
+            duration_seconds=2.0,
+            start_time=start,
+            end_time=start + timedelta(seconds=2),
+        )
+
+        result2 = ETLResult(
+            name="etl2",
+            status=ETLStatus.FAILED,
+            duration_seconds=1.0,
+            start_time=start,
+            end_time=start + timedelta(seconds=1),
+            error=ValueError("Test failure"),
+        )
+
+        aggregate = ParallelETLResult(
+            results=(result1, result2),
+            total_duration_seconds=2.0,
+            start_time=start,
+            end_time=start + timedelta(seconds=2),
+        )
+
+        assert not aggregate.all_successful
+        assert aggregate.success_count == 1
+        assert len(aggregate.failed_etls) == 1
+        assert aggregate.failed_etls[0].name == "etl2"
+
+    def test_reject_empty_results(self):
+        """Should reject aggregate with no results"""
+        start = datetime.now()
+
+        with pytest.raises(ValueError, match="Must have at least one ETL result"):
+            ParallelETLResult(
+                results=(),
+                total_duration_seconds=1.0,
+                start_time=start,
+                end_time=start + timedelta(seconds=1),
+            )
+
+
+class TestETLErrors:
+    """Test custom error types"""
+
+    def test_execution_error_requires_name(self):
+        """Should reject execution error without name"""
+        with pytest.raises(ValueError, match="ETL name cannot be empty"):
+            ETLExecutionError("", ValueError("test"))
+
+    def test_execution_error_requires_error(self):
+        """Should reject execution error without original error"""
+        with pytest.raises(ValueError, match="Original error cannot be None"):
+            ETLExecutionError("test", None)
+
+    def test_execution_error_message_format(self):
+        """Should format error message with context"""
+        orig_error = ValueError("original message")
+        error = ETLExecutionError("my_etl", orig_error)
+
+        assert "my_etl" in str(error)
+        assert "ValueError" in str(error)
+        assert "original message" in str(error)
+
+    def test_timeout_error_requires_name(self):
+        """Should reject timeout error without name"""
+        with pytest.raises(ValueError, match="ETL name cannot be empty"):
+            ETLTimeoutError("", 60)
+
+    def test_timeout_error_requires_positive_timeout(self):
+        """Should reject timeout error with non-positive timeout"""
+        with pytest.raises(ValueError, match="Timeout must be positive"):
+            ETLTimeoutError("test", 0)
+
+        with pytest.raises(ValueError, match="Timeout must be positive"):
+            ETLTimeoutError("test", -10)
+
+
+# Tests for the actual parallel execution logic
+
+
+class TestRunSingleETL:
+    """Tests for run_single_etl function"""
+
+    def test_run_successful_etl(self):
+        """Should execute ETL and return success result"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        # Mock ETL that succeeds
+        def mock_etl():
+            time.sleep(0.1)  # Simulate work
+
+        result = run_single_etl("test_etl", mock_etl, timeout=5)
+
+        assert result.name == "test_etl"
+        assert result.is_successful
+        assert result.status == ETLStatus.SUCCESS
+        assert result.duration_seconds >= 0.1
+        assert result.error is None
+
+    def test_run_failing_etl(self):
+        """Should capture ETL exception and return failed result"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        # Mock ETL that raises exception
+        def mock_etl():
+            raise ValueError("Test error")
+
+        result = run_single_etl("test_etl", mock_etl)
+
+        assert result.name == "test_etl"
+        assert not result.is_successful
+        assert result.status == ETLStatus.FAILED
+        assert result.error is not None
+        assert isinstance(result.error, ETLExecutionError)
+        assert "Test error" in str(result.error)
+
+    def test_timeout_slow_etl(self):
+        """Should timeout ETL that takes too long"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        # Mock ETL that takes forever
+        def slow_etl():
+            time.sleep(10)  # 10 seconds
+
+        result = run_single_etl("slow_etl", slow_etl, timeout=1)
+
+        assert result.name == "slow_etl"
+        assert not result.is_successful
+        assert result.status == ETLStatus.TIMEOUT
+        assert result.error is not None
+        assert isinstance(result.error, ETLTimeoutError)
+
+    def test_reject_empty_name(self):
+        """Should reject ETL with empty name"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        with pytest.raises(ETLValidationError, match="name cannot be empty"):
+            run_single_etl("", lambda: None)
+
+    def test_reject_whitespace_name(self):
+        """Should reject ETL with whitespace name"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        with pytest.raises(ETLValidationError, match="name cannot be empty"):
+            run_single_etl("   ", lambda: None)
+
+    def test_reject_none_function(self):
+        """Should reject None as ETL function"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        with pytest.raises(ETLValidationError, match="cannot be None"):
+            run_single_etl("test", None)
+
+    def test_reject_non_callable(self):
+        """Should reject non-callable as ETL function"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        with pytest.raises(ETLValidationError, match="must be callable"):
+            run_single_etl("test", "not a function")
+
+    def test_reject_negative_timeout(self):
+        """Should reject negative timeout"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        with pytest.raises(ETLValidationError, match="must be positive"):
+            run_single_etl("test", lambda: None, timeout=-1)
+
+    def test_reject_zero_timeout(self):
+        """Should reject zero timeout"""
+        from backend.etl.parallel_etl import run_single_etl
+
+        with pytest.raises(ETLValidationError, match="must be positive"):
+            run_single_etl("test", lambda: None, timeout=0)
+
+
+class TestRunParallelETLs:
+    """Tests for run_parallel_etls function"""
+
+    def test_run_multiple_etls_successfully(self):
+        """Should run multiple ETLs in parallel and all succeed"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        # Mock ETLs with different durations
+        def etl1():
+            time.sleep(0.2)
+
+        def etl2():
+            time.sleep(0.15)
+
+        def etl3():
+            time.sleep(0.1)
+
+        etl_map = {"etl1": etl1, "etl2": etl2, "etl3": etl3}
+
+        result = run_parallel_etls(etl_map)
+
+        assert result.all_successful
+        assert result.success_count == 3
+        assert len(result.failed_etls) == 0
+        assert result.total_duration_seconds < 0.4  # Some margin
+
+    def test_handle_one_etl_failure(self):
+        """Should continue other ETLs when one fails"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        def success_etl():
+            time.sleep(0.1)
+
+        def failing_etl():
+            raise ValueError("Intentional failure")
+
+        etl_map = {
+            "success1": success_etl,
+            "failure": failing_etl,
+            "success2": success_etl,
+        }
+
+        result = run_parallel_etls(etl_map)
+
+        assert not result.all_successful
+        assert result.success_count == 2
+        assert len(result.failed_etls) == 1
+        assert result.failed_etls[0].name == "failure"
+
+    def test_handle_all_etls_failing(self):
+        """Should handle all ETLs failing"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        def failing_etl1():
+            raise ValueError("Error 1")
+
+        def failing_etl2():
+            raise RuntimeError("Error 2")
+
+        etl_map = {"fail1": failing_etl1, "fail2": failing_etl2}
+
+        result = run_parallel_etls(etl_map)
+
+        assert not result.all_successful
+        assert result.success_count == 0
+        assert len(result.failed_etls) == 2
+
+    def test_handle_timeout_in_parallel(self):
+        """Should handle timeout of one ETL while others complete"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        def fast_etl():
+            time.sleep(0.1)
+
+        def slow_etl():
+            time.sleep(5)
+
+        etl_map = {"fast": fast_etl, "slow": slow_etl}
+
+        result = run_parallel_etls(etl_map, timeout_per_etl=1)
+
+        assert not result.all_successful
+        assert result.success_count == 1
+
+        # Find the slow ETL result
+        slow_result = next(r for r in result.results if r.name == "slow")
+        assert slow_result.status == ETLStatus.TIMEOUT
+
+    def test_reject_empty_etl_map(self):
+        """Should reject empty ETL map"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        with pytest.raises(ETLValidationError, match="cannot be empty"):
+            run_parallel_etls({})
+
+    def test_reject_etl_with_empty_name(self):
+        """Should reject ETL map with empty name"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        with pytest.raises(ETLValidationError, match="must be non-empty"):
+            run_parallel_etls({"": lambda: None})
+
+    def test_reject_etl_with_non_callable(self):
+        """Should reject ETL map with non-callable"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        with pytest.raises(ETLValidationError, match="not callable"):
+            run_parallel_etls({"test": "not a function"})
+
+    def test_reject_negative_timeout(self):
+        """Should reject negative timeout"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        with pytest.raises(ETLValidationError, match="must be positive"):
+            run_parallel_etls({"test": lambda: None}, timeout_per_etl=-1)
+
+    def test_reject_negative_max_workers(self):
+        """Should reject negative max_workers"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        with pytest.raises(ETLValidationError, match="must be positive"):
+            run_parallel_etls({"test": lambda: None}, max_workers=-1)
+
+    def test_single_etl(self):
+        """Should handle single ETL"""
+        from backend.etl.parallel_etl import run_parallel_etls
+
+        def single_etl():
+            time.sleep(0.1)
+
+        result = run_parallel_etls({"single": single_etl})
+
+        assert result.all_successful
+        assert result.success_count == 1

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,7 +50,7 @@ services:
       interval: 500s
       timeout: 5s
       retries: 5
-      start_period: 30s
+      start_period: 60s  # Increased from 30s to accommodate ETL startup time (~47s)
 
   db_test:
     build:


### PR DESCRIPTION
# Description

Fixes backend container healthcheck timeout in CI by increasing Docker healthcheck wait time and implementing parallel ETL execution to reduce startup time from ~47s to ~28s.

Fixes #762

__Key Changes:__

- Increased healthcheck `start_period` from 30s to 60s
- Added parallel ETL orchestration system (`parallel_etl.py`, `parallel_etl_types.py`)
- Replaced serial for-loop in `startup.sh` with parallel runner (`run_parallel_etls.py`)
- 37 comprehensive tests with type safety and error handling

__Technical Details:__

- Uses `ThreadPoolExecutor` for concurrent ETL execution
- Individual timeout protection per ETL (180s default)
- Proper error capture and aggregation
- No changes to existing ETL handlers

## Type of changes

- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing

- (x) I added automated tests
- ( ) I think tests are unnecessary

## How to test

__1. Verify CI healthcheck passes:__

```bash
docker compose down -v
docker compose up -d --wait --wait-timeout 120
docker ps  # All containers should show "(healthy)"
```

__2. Verify parallel execution works:__

```bash
docker compose logs backend | grep "PARALLEL_ETL"
# Should see: "Starting 3 ETL processes in parallel"
# Should see: "All 3 ETLs succeeded in ~22-28s"
```

__3. Run automated tests:__

```bash
docker compose exec backend /.venv/bin/pytest backend/etl/tests/test_parallel_etl.py -v
# Expected: 37 passed
```

__4. Verify app functionality:__

- Start app at [](http://localhost:3000)<http://localhost:3000>
- Enter any SF address
- Confirm hazard data displays correctly (tsunami, liquefaction, soft story)

## Clean commits

- ( ) I plan to Squash and Merge
- (x) My commit history is clean¹