### PR TITLE
Bug fix to remove searched address when clicking on SafeHome logo

### DIFF
--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -48,7 +48,7 @@ const ComponentsTestLib = () => {
           <Box w="sm">
             <Suspense fallback={<SearchBarSkeleton />}>
               {/* NOTE: This Suspense boundary is being used around a component that utilizes `useSearchParams()` to prevent entire page from deopting into client-side rendering (CSR) bailout as per https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout */}
-              <SearchBar 
+              <SearchBar
                 inputAddress=""
                 onInputAddressChange={() => {}}
                 onSearchChange={() => {}}

--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -48,7 +48,7 @@ const ComponentsTestLib = () => {
           <Box w="sm">
             <Suspense fallback={<SearchBarSkeleton />}>
               {/* NOTE: This Suspense boundary is being used around a component that utilizes `useSearchParams()` to prevent entire page from deopting into client-side rendering (CSR) bailout as per https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout */}
-              <SearchBar onSearchChange={() => {}} />
+              <SearchBar inputAddress="" onInputAddressChange={() => {}} onSearchChange={() => {}} />
             </Suspense>
           </Box>
         </HStack>

--- a/app/components-test-lib/page.tsx
+++ b/app/components-test-lib/page.tsx
@@ -48,7 +48,11 @@ const ComponentsTestLib = () => {
           <Box w="sm">
             <Suspense fallback={<SearchBarSkeleton />}>
               {/* NOTE: This Suspense boundary is being used around a component that utilizes `useSearchParams()` to prevent entire page from deopting into client-side rendering (CSR) bailout as per https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout */}
-              <SearchBar inputAddress="" onInputAddressChange={() => {}} onSearchChange={() => {}} />
+              <SearchBar 
+                inputAddress=""
+                onInputAddressChange={() => {}}
+                onSearchChange={() => {}}
+              />
             </Suspense>
           </Box>
         </HStack>

--- a/app/components-test-lib/search-bar-client-wrapper.tsx
+++ b/app/components-test-lib/search-bar-client-wrapper.tsx
@@ -3,6 +3,12 @@
 import SearchBar from "../components/search-bar";
 
 // NOTE: SearchBar resides here instead of directly in the components test library because event handlers are not allowed to be passed into a Client Component from a Server Component
-const SearchBarClientWrapper = ({}) => <SearchBar inputAddress="" onInputAddressChange={() => {}} onSearchChange={() => {}} />;
+const SearchBarClientWrapper = ({}) => (
+  <SearchBar
+    inputAddress=""
+    onInputAddressChange={() => {}}
+    onSearchChange={() => {}}
+  />
+);
 
 export default SearchBarClientWrapper;

--- a/app/components-test-lib/search-bar-client-wrapper.tsx
+++ b/app/components-test-lib/search-bar-client-wrapper.tsx
@@ -3,6 +3,6 @@
 import SearchBar from "../components/search-bar";
 
 // NOTE: SearchBar resides here instead of directly in the components test library because event handlers are not allowed to be passed into a Client Component from a Server Component
-const SearchBarClientWrapper = ({}) => <SearchBar onSearchChange={() => {}} />;
+const SearchBarClientWrapper = ({}) => <SearchBar inputAddress="" onInputAddressChange={() => {}} onSearchChange={() => {}} />;
 
 export default SearchBarClientWrapper;

--- a/app/components/home-header.tsx
+++ b/app/components/home-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Headings } from "../data/data";
 import {
@@ -35,6 +35,7 @@ const HomeHeader = ({
   isSearchComplete,
   onSearchChange,
 }: HomeHeaderProps) => {
+  const [inputAddress, setInputAddress] = useState("");
   const headingData = Headings.home;
   const router = useRouter();
 
@@ -60,6 +61,7 @@ const HomeHeader = ({
             textDecoration={"none"}
             onClick={(e) => {
               e.preventDefault();
+              setInputAddress("");
               router.push("/");
             }}
           >
@@ -91,7 +93,11 @@ const HomeHeader = ({
         alignItems={{ base: "flex-start", xl: "center" }}
       >
         <Box width={{ base: "full", xl: "fit" }}>
-          <SearchBar onSearchChange={onSearchChange} />
+          <SearchBar 
+            inputAddress={inputAddress}
+            onInputAddressChange={setInputAddress}
+            onSearchChange={onSearchChange}
+          />
         </Box>
 
         {/* NOTE: This Suspense boundary is being used around a component that utilizes `useSearchParams()` to prevent entire page from deopting into client-side rendering (CSR) bailout as per https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout */}

--- a/app/components/home-header.tsx
+++ b/app/components/home-header.tsx
@@ -93,7 +93,7 @@ const HomeHeader = ({
         alignItems={{ base: "flex-start", xl: "center" }}
       >
         <Box width={{ base: "full", xl: "fit" }}>
-          <SearchBar 
+          <SearchBar
             inputAddress={inputAddress}
             onInputAddressChange={setInputAddress}
             onSearchChange={onSearchChange}

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { ChangeEvent, FormEvent, Suspense, useState, Dispatch, SetStateAction } from "react";
+import { 
+  ChangeEvent, 
+  FormEvent, 
+  Suspense, 
+  useState, 
+  Dispatch, 
+  SetStateAction 
+} from "react";
 import { useRouter } from "next/navigation";
 import { chakra, Input, InputGroup, Text } from "@chakra-ui/react";
 import { IoSearchSharp } from "react-icons/io5";

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChangeEvent, FormEvent, Suspense, useState } from "react";
+import { ChangeEvent, FormEvent, Suspense, useState, Dispatch, SetStateAction } from "react";
 import { useRouter } from "next/navigation";
 import { chakra, Input, InputGroup, Text } from "@chakra-ui/react";
 import { IoSearchSharp } from "react-icons/io5";
@@ -23,18 +23,19 @@ const autofillOptions: AddressAutofillOptions = {
 // NOTE: UI changes to this page ought to be reflected in its suspense skeleton `search-bar-skeleton.tsx` and vice versa
 // TODO: isolate the usage of `useSearchParams()` so that the Suspense boundary can be even more narrow if possible
 interface SearchBarProps {
+  inputAddress: string;
+  onInputAddressChange: Dispatch<SetStateAction<string>>;
   onSearchChange: (coords: number[], address: string) => void;
 }
 
-const SearchBar = ({ onSearchChange }: SearchBarProps) => {
-  const [inputAddress, setInputAddress] = useState("");
+const SearchBar = ({ inputAddress, onInputAddressChange, onSearchChange }: SearchBarProps) => {
   const [suggestionSelected, setSuggestionSelected] = useState(false);
   const [suggestionsAvailable, setSuggestionsAvailable] = useState(false);
   const router = useRouter();
   const characterCap = 5;
 
   const handleClearClick = () => {
-    setInputAddress("");
+    onInputAddressChange("");
     setSuggestionSelected(false);
     router.push("/", { scroll: false });
   };
@@ -55,7 +56,7 @@ const SearchBar = ({ onSearchChange }: SearchBarProps) => {
   };
 
   const handleAddressChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setInputAddress(event.currentTarget.value);
+    onInputAddressChange(event.currentTarget.value);
     // shows hint again upon further search param changes without selection of suggestion
     if (!suggestionSelected) setSuggestionsAvailable(false);
     else if (suggestionSelected && inputAddress.length <= 3) {

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import { 
-  ChangeEvent, 
-  FormEvent, 
-  Suspense, 
-  useState, 
-  Dispatch, 
-  SetStateAction 
-} from "react";
+import { ChangeEvent, FormEvent, Suspense, useState } from "react";
 import { useRouter } from "next/navigation";
 import { chakra, Input, InputGroup, Text } from "@chakra-ui/react";
 import { IoSearchSharp } from "react-icons/io5";
@@ -31,7 +24,7 @@ const autofillOptions: AddressAutofillOptions = {
 // TODO: isolate the usage of `useSearchParams()` so that the Suspense boundary can be even more narrow if possible
 interface SearchBarProps {
   inputAddress: string;
-  onInputAddressChange: Dispatch<SetStateAction<string>>;
+  onInputAddressChange: (address: string) => void;
   onSearchChange: (coords: number[], address: string) => void;
 }
 

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -28,7 +28,11 @@ interface SearchBarProps {
   onSearchChange: (coords: number[], address: string) => void;
 }
 
-const SearchBar = ({ inputAddress, onInputAddressChange, onSearchChange }: SearchBarProps) => {
+const SearchBar = ({ 
+  inputAddress, 
+  onInputAddressChange, 
+  onSearchChange,
+ }: SearchBarProps) => {
   const [suggestionSelected, setSuggestionSelected] = useState(false);
   const [suggestionsAvailable, setSuggestionsAvailable] = useState(false);
   const router = useRouter();

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -28,11 +28,11 @@ interface SearchBarProps {
   onSearchChange: (coords: number[], address: string) => void;
 }
 
-const SearchBar = ({ 
-  inputAddress, 
-  onInputAddressChange, 
+const SearchBar = ({
+  inputAddress,
+  onInputAddressChange,
   onSearchChange,
- }: SearchBarProps) => {
+}: SearchBarProps) => {
   const [suggestionSelected, setSuggestionSelected] = useState(false);
   const [suggestionsAvailable, setSuggestionsAvailable] = useState(false);
   const router = useRouter();


### PR DESCRIPTION
# Description

- Fixes https://github.com/sfbrigade/datasci-earthquake/issues/664

Lifted `inputAddress` state up from `SearchBar` to `HomeHeader` component and now reset the address when the SafeHome logo is clicked. See Gemini summary in comment below for more info.

Screen recording shows that the search bar is cleared after clicking on the logo and the x button to clear the address is still working.

https://github.com/user-attachments/assets/b9ef8b9c-2be7-47a8-91ff-23c2454ab7f6


## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- ( ) I think tests are unnecessary

There is a test file for SearchBar tests but it looks like they are being skipped due to an issue so didn't add a test.

## How to test

_testing description here: i.e. run app, go to x page, see that it does y_

## Clean commits
- (x) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
