### PR TITLE
[Temporary] Increased docker compose up timeout duration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         run: docker compose build
 
       - name: Start Services
-        run: docker compose up -d --wait --wait-timeout 120
+        run: docker compose up -d --wait --wait-timeout 300
 
       - name: Docker Logs 
         if: always()  

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,7 +18,7 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000 || exit 1"]
       start_interval: 10s
-      interval: 500s
+      interval: 10s
       timeout: 5s
       retries: 6
       start_period: 60s
@@ -47,7 +47,7 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/api/health || exit 1"]
       start_interval: 10s
-      interval: 500s
+      interval: 10s
       timeout: 5s
       retries: 10
       start_period: 30s
@@ -69,7 +69,7 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       start_interval: 10s
-      interval: 500s
+      interval: 10s
       timeout: 5s
       retries: 10
       start_period: 30s
@@ -93,7 +93,7 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       start_interval: 10s
-      interval: 500s
+      interval: 10s
       timeout: 5s
       retries: 10
       start_period: 30s

--- a/compose.yaml
+++ b/compose.yaml
@@ -20,7 +20,7 @@ services:
       start_interval: 10s
       interval: 500s
       timeout: 5s
-      retries: 3
+      retries: 6
       start_period: 60s
     command: npm run next-dev
 
@@ -49,7 +49,7 @@ services:
       start_interval: 10s
       interval: 500s
       timeout: 5s
-      retries: 5
+      retries: 10
       start_period: 30s
 
   db_test:
@@ -71,7 +71,7 @@ services:
       start_interval: 10s
       interval: 500s
       timeout: 5s
-      retries: 5
+      retries: 10
       start_period: 30s
     depends_on:
       - db
@@ -95,7 +95,7 @@ services:
       start_interval: 10s
       interval: 500s
       timeout: 5s
-      retries: 5
+      retries: 10
       start_period: 30s
 
 volumes:


### PR DESCRIPTION
# Description

Increased --wait-timeout parameter in Start Services job to 5 minutes
Increased the number of retries per healthcheck and shortened interval between healthchecks.

This is a **TEMPORARY** band-aid fix to this issue, where the "docker compose up" command fails to return a healthy response before the 2-minute timeout duration. Investigating and fixing docker initialization logic has been noted as issue #782. However, in the mean-time, we need a temporary fix to allow CI to return a healthy response.

## Clean commits
- ( ) I plan to Squash and Merge
- (X) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
