### PR TITLE
chore: skip CI for markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,14 @@ name: CI Pipeline
 
 on:
   push:
+    paths-ignore:
+      - '**.md'
     branches:
       - develop
       - main
   pull_request:
+    paths-ignore:
+      - '**.md'
     types: [opened, synchronize, reopened]
     branches:
       - develop


### PR DESCRIPTION
# Description
Update the CI workflow triggers to ignore markdown-only changes on push and pull_request. This skips lint/build/docker jobs for documentation-only updates, reducing unnecessary CI load and avoiding unrelated failures.

Closes #793 (relates to #782).

How it works

- The workflow is defined in [ci.yml](vscode-file://vscode-app/c:/Users/arora/AppData/Local/Programs/Microsoft%20VS%20Code/591199df40/resources/app/out/vs/code/electron-browser/workbench/workbench.html), and GitHub Actions decides whether to run it based on the on: section.
- The workflow still runs on push and pull_request to develop and main, except when all changed files match **.md (new paths-ignore rule).
- If triggered, jobs run in parallel: eslint, black_lint_and_mypy_type_check, nextjs_build_check, docker_build_test.

## Type of changes
- ( ) Bugfix
- (x) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test

Open a PR that only changes a .md file and confirm the CI workflow does not trigger.
Then add a non-markdown file change and confirm the CI workflow runs.

## Clean commits
- ( ) I plan to Squash and Merge
- (x) My commit history is clean¹
  ¹Single, focused commit with clear message.
