### PR TITLE
Update CI workflow to include markdown files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,10 @@ name: CI Pipeline
 
 on:
   push:
-    paths-ignore:
-      - '**.md'
     branches:
       - develop
       - main
   pull_request:
-    paths-ignore:
-      - '**.md'
     types: [opened, synchronize, reopened]
     branches:
       - develop


### PR DESCRIPTION
# Description

Removed paths-ignore for markdown files in CI triggers.

This reverts PR #812 so markdown-only PRs can be unblocked.

## Type of changes
- (X) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

_testing description here: i.e. run app, go to x page, see that it does y_

## Clean commits
- (X) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](./README.md#pull-requests)
