### PR TITLE
chore: skip CI for markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,115 +61,76 @@ jobs:
           fi
 
   eslint:
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     needs: changes
     steps:
-      - name: Skip (markdown-only changes)
-        if: needs.changes.outputs.code_changed != 'true'
-        run: echo "Skipping ESLint (markdown-only changes)."
-
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.code_changed == 'true'
-
       - uses: ./.github/actions/setup-node-using-nvmrc
-        if: needs.changes.outputs.code_changed == 'true'
-
       - name: Install Node.js dependencies
-        if: needs.changes.outputs.code_changed == 'true'
         run: npm ci
-
       - name: Run ESLint
-        if: needs.changes.outputs.code_changed == 'true'
         run: npm run lint
 
   black_lint_and_mypy_type_check:
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     needs: changes
     steps:
-      - name: Skip (markdown-only changes)
-        if: needs.changes.outputs.code_changed != 'true'
-        run: echo "Skipping Black/MyPy (markdown-only changes)."
-
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.code_changed == 'true'
-
       - name: Set up Python
-        if: needs.changes.outputs.code_changed == 'true'
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
-
       - name: Install uv
-        if: needs.changes.outputs.code_changed == 'true'
         run: curl -sSL https://astral.sh/uv/install.sh | sh
-
       - name: Install dependencies with uv
-        if: needs.changes.outputs.code_changed == 'true'
         run: |
           uv pip install --system black==24.10.0 mypy
           uv pip install --system fastapi pydantic pydantic-settings sqlalchemy GeoAlchemy2 pytest
-
       - name: Check code formatting with black
-        if: needs.changes.outputs.code_changed == 'true'
         run: black --check .
-
       - name: Type check with mypy
-        if: needs.changes.outputs.code_changed == 'true'
         run: mypy --config-file mypy.ini .
 
   nextjs_build_check:
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     needs: changes
     env:
       ENVIRONMENT: ci
     steps:
-      - name: Skip (markdown-only changes)
-        if: needs.changes.outputs.code_changed != 'true'
-        run: echo "Skipping Next.js build (markdown-only changes)."
-
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.code_changed == 'true'
-
       - uses: ./.github/actions/setup-node-using-nvmrc
-        if: needs.changes.outputs.code_changed == 'true'
-
       - name: Install dependencies
-        if: needs.changes.outputs.code_changed == 'true'
         run: npm ci
-
       - name: Check Next.js production build
-        if: needs.changes.outputs.code_changed == 'true'
         run: npm run build
 
   docker_build_test:
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     needs: changes
     steps:
-      - name: Skip (markdown-only changes)
-        if: needs.changes.outputs.code_changed != 'true'
-        run: echo "Skipping Docker/test jobs (markdown-only changes)."
-
       - name: Checkout Code
-        if: needs.changes.outputs.code_changed == 'true'
         uses: actions/checkout@v4
 
       - name: Set default fork status
-        if: needs.changes.outputs.code_changed == 'true'
         run: echo "is_fork=false" >> $GITHUB_ENV
 
       - name: Check if pull request from fork
-        if: needs.changes.outputs.code_changed == 'true' && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
             echo "is_fork=true" >> $GITHUB_ENV
           fi
 
       - name: Use .env.example for forks
-        if: needs.changes.outputs.code_changed == 'true' && env.is_fork == 'true'
+        if: env.is_fork == 'true'
         run: cp .env.example .env
 
       - name: Get Run ID of Most Recent Successful Run
-        if: needs.changes.outputs.code_changed == 'true' && env.is_fork != 'true'
+        if: env.is_fork != 'true'
         run: |
           response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/sfbrigade/datasci-earthquake/actions/workflows/env_vars.yml/runs?status=completed&conclusion=success")
@@ -178,7 +139,7 @@ jobs:
           echo "run_id=$run_id" >> $GITHUB_ENV
 
       - name: Download .env Artifact
-        if: needs.changes.outputs.code_changed == 'true' && env.is_fork != 'true'
+        if: env.is_fork != 'true'
         uses: actions/download-artifact@v4
         with:
           name: encrypted-env-file
@@ -187,13 +148,12 @@ jobs:
           run-id: ${{ env.run_id }}
 
       - name: Decrypt .env File
-        if: needs.changes.outputs.code_changed == 'true' && env.is_fork != 'true'
+        if: env.is_fork != 'true'
         run: |
           openssl aes-256-cbc -d -salt -pbkdf2 -k "${{ secrets.ARTIFACT_PASS }}" -in .env.enc -out .env
           echo "Decryption complete"
 
       - name: Ensure .env exists
-        if: needs.changes.outputs.code_changed == 'true'
         run: |
           if [ ! -f .env ]; then
             echo ".env not found. Falling back to .env.example"
@@ -201,11 +161,9 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        if: needs.changes.outputs.code_changed == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        if: needs.changes.outputs.code_changed == 'true'
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
@@ -214,37 +172,32 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build Docker Containers
-        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose build
 
       - name: Start Services
-        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose up -d --wait --wait-timeout 300
 
       - name: Docker Backend Logs
-        if: always() && needs.changes.outputs.code_changed == 'true'
+        if: always()
         run: docker logs datasci-earthquake-backend-1 || echo "No logs found"
 
       - name: Docker DB Logs
-        if: always() && needs.changes.outputs.code_changed == 'true'
+        if: always()
         run: docker logs my_postgis_db || echo "No logs found"
 
       - name: Docker DB Test (unit tests) Logs
-        if: always() && needs.changes.outputs.code_changed == 'true'
+        if: always()
         run: docker logs my_postgis_db_test || echo "No logs found"
 
       - name: Docker Frontend Logs
-        if: always() && needs.changes.outputs.code_changed == 'true'
+        if: always()
         run: docker logs datasci-earthquake-frontend-1 || echo "No logs found"
 
       - name: Run Backend Tests
-        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose run --rm backend pytest backend -v
 
       - name: Run Frontend Tests
-        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose run --rm frontend npm test
 
       - name: Clean Up
-        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,91 +10,176 @@ on:
     branches:
       - develop
       - main
+      - chore/ci-ignore-markdown
 
 jobs:
-  eslint:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.detect.outputs.code_changed }}
+      docs_only: ${{ steps.detect.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect markdown-only changes
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+            # handle first push on branch where "before" can be all zeros
+            if [[ "$BASE_SHA" =~ ^0+$ ]]; then
+              BASE_SHA="$(git rev-list --max-parents=0 HEAD | tail -n1)"
+            fi
+          fi
+
+          CHANGED_FILES="$(git diff --name-only "$BASE_SHA" "${{ github.sha }}")"
+
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          if [[ -z "$CHANGED_FILES" ]]; then
+            # fallback: run full CI if no diff detected
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          NON_MD_FILES="$(printf "%s\n" "$CHANGED_FILES" | grep -Ev '(^$|.*\.mdx?$)' || true)"
+
+          if [[ -z "$NON_MD_FILES" ]]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            echo "code_changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "code_changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  eslint:
+    runs-on: ubuntu-latest
+    needs: changes
+    steps:
+      - name: Skip (markdown-only changes)
+        if: needs.changes.outputs.code_changed != 'true'
+        run: echo "Skipping ESLint (markdown-only changes)."
+
+      - uses: actions/checkout@v4
+        if: needs.changes.outputs.code_changed == 'true'
 
       - uses: ./.github/actions/setup-node-using-nvmrc
+        if: needs.changes.outputs.code_changed == 'true'
 
       - name: Install Node.js dependencies
+        if: needs.changes.outputs.code_changed == 'true'
         run: npm ci
 
       - name: Run ESLint
+        if: needs.changes.outputs.code_changed == 'true'
         run: npm run lint
 
   black_lint_and_mypy_type_check:
     runs-on: ubuntu-latest
+    needs: changes
     steps:
+      - name: Skip (markdown-only changes)
+        if: needs.changes.outputs.code_changed != 'true'
+        run: echo "Skipping Black/MyPy (markdown-only changes)."
+
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.code_changed == 'true'
+
       - name: Set up Python
+        if: needs.changes.outputs.code_changed == 'true'
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: "3.x"
 
       - name: Install uv
-        run: |
-          curl -sSL https://astral.sh/uv/install.sh | sh
-          
+        if: needs.changes.outputs.code_changed == 'true'
+        run: curl -sSL https://astral.sh/uv/install.sh | sh
+
       - name: Install dependencies with uv
+        if: needs.changes.outputs.code_changed == 'true'
         run: |
           uv pip install --system black==24.10.0 mypy
           uv pip install --system fastapi pydantic pydantic-settings sqlalchemy GeoAlchemy2 pytest
 
       - name: Check code formatting with black
+        if: needs.changes.outputs.code_changed == 'true'
         run: black --check .
 
       - name: Type check with mypy
+        if: needs.changes.outputs.code_changed == 'true'
         run: mypy --config-file mypy.ini .
 
   nextjs_build_check:
     runs-on: ubuntu-latest
+    needs: changes
     env:
       ENVIRONMENT: ci
     steps:
-      - uses: actions/checkout@v4 
+      - name: Skip (markdown-only changes)
+        if: needs.changes.outputs.code_changed != 'true'
+        run: echo "Skipping Next.js build (markdown-only changes)."
+
+      - uses: actions/checkout@v4
+        if: needs.changes.outputs.code_changed == 'true'
+
       - uses: ./.github/actions/setup-node-using-nvmrc
+        if: needs.changes.outputs.code_changed == 'true'
+
       - name: Install dependencies
-        run: npm ci 
+        if: needs.changes.outputs.code_changed == 'true'
+        run: npm ci
+
       - name: Check Next.js production build
+        if: needs.changes.outputs.code_changed == 'true'
         run: npm run build
 
   docker_build_test:
     runs-on: ubuntu-latest
+    needs: changes
     steps:
+      - name: Skip (markdown-only changes)
+        if: needs.changes.outputs.code_changed != 'true'
+        run: echo "Skipping Docker/test jobs (markdown-only changes)."
+
       - name: Checkout Code
+        if: needs.changes.outputs.code_changed == 'true'
         uses: actions/checkout@v4
 
       - name: Set default fork status
-        run: echo "is_fork=false" >> $GITHUB_ENV        
+        if: needs.changes.outputs.code_changed == 'true'
+        run: echo "is_fork=false" >> $GITHUB_ENV
 
       - name: Check if pull request from fork
-        id: check_fork
-        if: github.event_name == 'pull_request'
+        if: needs.changes.outputs.code_changed == 'true' && github.event_name == 'pull_request'
         run: |
-          run: |
-            if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-              echo "is_fork=true" >> $GITHUB_ENV
-            fi
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is_fork=true" >> $GITHUB_ENV
+          fi
 
       - name: Use .env.example for forks
-        if: env.is_fork == 'true'
+        if: needs.changes.outputs.code_changed == 'true' && env.is_fork == 'true'
         run: cp .env.example .env
 
       - name: Get Run ID of Most Recent Successful Run
-        id: get_run_id
-        if: env.is_fork != 'true'
+        if: needs.changes.outputs.code_changed == 'true' && env.is_fork != 'true'
         run: |
           response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/sfbrigade/datasci-earthquake/actions/workflows/env_vars.yml/runs?status=completed&conclusion=success")
-          run_id=$(echo $response | jq '.workflow_runs[0].id')
+          run_id=$(echo "$response" | jq '.workflow_runs[0].id')
           echo "Run ID: $run_id"
           echo "run_id=$run_id" >> $GITHUB_ENV
 
       - name: Download .env Artifact
-        if: env.is_fork != 'true'
+        if: needs.changes.outputs.code_changed == 'true' && env.is_fork != 'true'
         uses: actions/download-artifact@v4
         with:
           name: encrypted-env-file
@@ -103,12 +188,13 @@ jobs:
           run-id: ${{ env.run_id }}
 
       - name: Decrypt .env File
-        if: env.is_fork != 'true'
+        if: needs.changes.outputs.code_changed == 'true' && env.is_fork != 'true'
         run: |
           openssl aes-256-cbc -d -salt -pbkdf2 -k "${{ secrets.ARTIFACT_PASS }}" -in .env.enc -out .env
           echo "Decryption complete"
 
       - name: Ensure .env exists
+        if: needs.changes.outputs.code_changed == 'true'
         run: |
           if [ ! -f .env ]; then
             echo ".env not found. Falling back to .env.example"
@@ -116,9 +202,11 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
+        if: needs.changes.outputs.code_changed == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
+        if: needs.changes.outputs.code_changed == 'true'
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
@@ -127,36 +215,37 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Build Docker Containers
+        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose build
 
       - name: Start Services
+        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose up -d --wait --wait-timeout 300
 
-      - name: Docker Backend Logs 
-        if: always()
-        run: |
-          docker logs datasci-earthquake-backend-1 || echo "No logs found"
+      - name: Docker Backend Logs
+        if: always() && needs.changes.outputs.code_changed == 'true'
+        run: docker logs datasci-earthquake-backend-1 || echo "No logs found"
 
-      - name: Docker DB Logs 
-        if: always()
-        run: |
-          docker logs my_postgis_db || echo "No logs found"
+      - name: Docker DB Logs
+        if: always() && needs.changes.outputs.code_changed == 'true'
+        run: docker logs my_postgis_db || echo "No logs found"
 
-      - name: Docker DB Test (unit tests) Logs 
-        if: always()
-        run: |
-          docker logs my_postgis_db_test || echo "No logs found"
+      - name: Docker DB Test (unit tests) Logs
+        if: always() && needs.changes.outputs.code_changed == 'true'
+        run: docker logs my_postgis_db_test || echo "No logs found"
 
-      - name: Docker Frontend Logs 
-        if: always()
-        run: |
-          docker logs datasci-earthquake-frontend-1 || echo "No logs found"
+      - name: Docker Frontend Logs
+        if: always() && needs.changes.outputs.code_changed == 'true'
+        run: docker logs datasci-earthquake-frontend-1 || echo "No logs found"
 
       - name: Run Backend Tests
+        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose run --rm backend pytest backend -v
 
       - name: Run Frontend Tests
+        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose run --rm frontend npm test
 
       - name: Clean Up
+        if: needs.changes.outputs.code_changed == 'true'
         run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code_changed: ${{ steps.detect.outputs.code_changed }}
-      docs_only: ${{ steps.detect.outputs.docs_only }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,7 +44,6 @@ jobs:
 
           if [[ -z "$CHANGED_FILES" ]]; then
             # fallback: run full CI if no diff detected
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "code_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -53,10 +51,8 @@ jobs:
           NON_MD_FILES="$(printf "%s\n" "$CHANGED_FILES" | grep -Ev '(^$|.*\.mdx?$)' || true)"
 
           if [[ -z "$NON_MD_FILES" ]]; then
-            echo "docs_only=true" >> "$GITHUB_OUTPUT"
             echo "code_changed=false" >> "$GITHUB_OUTPUT"
           else
-            echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "code_changed=true" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - develop
       - main
+      - chore/ci-ignore-markdown
 
 jobs:
   changes:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - develop
       - main
-      - chore/ci-ignore-markdown
 
 jobs:
   changes:


### PR DESCRIPTION
# Description

This PR is a continuation of PR #812. These jobs are required under branch protection rules, so this PR skips them at the job level rather than the workflow-trigger level. This reduces unnecessary CI runtime while preserving required status checks for protected branches.

- Adds a changes detection job to identify when a PR/push modifies only *.md/*.mdx files.
- Keeps required CI jobs running so branch protection checks are still reported.
- For markdown-only changes, required jobs execute lightweight skip steps and exit successfully.
- For non-markdown changes, jobs run normally.

Closes issue #833 

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

I temporarily changed the `branches:` list to include `chore/ci-ignore-markdown`, then created test PRs for this branch.
Markdown-only PR: #845 
Non-Markdown PR: #846 

Both PRs report 8 completed status checks, but the markdown-only PR skips all of the steps and returns the status much quicker.

**NEW** Markdown-only PR: #849

Now the markdown-only PR more accurately reports the skipped jobs as being skipped.

## Clean commits
- (X) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
