### PR TITLE
allow CI to run for any PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - develop
-      - main
 
 jobs:
   eslint:


### PR DESCRIPTION
# Description

CI runs only on PRs to `develop` or `main`. However, there may be PRs that opened into other branches as well and it would be desirable to run CI there too.

This PR allows CI to run on all PRs.

## Type of changes
- ( ) Bugfix
- (x) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test

open a PR with this branch and set the target branch to be a branch other than `develop` or `main`. then check the PR to see if CI is running.

## Clean commits
- ( ) I plan to Squash and Merge
- (x) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
