### PR TITLE
add auto vertical scrollbar to desktop hazard cards

### DIFF
--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Box } from "@chakra-ui/react";
+import { Box, Flex, HStack } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { toaster } from "@/components/ui/toaster";
 import Map from "./map";
@@ -205,37 +205,41 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
           md: { "--header-height": "175px" },
           xl: { "--header-height": "141px" },
           "2xl": { "--header-height": "149px" },
-          "--whitespace-height": "32px",
+          "--whitespace-height": "96px",
+          "--map-height":
+            "calc(100dvh - var(--header-height) - var(--whitespace-height))",
         }}
-        style={{
-          height:
-            "calc(100dvh - var(--header-height) - var(--whitespace-height)",
-        }}
+        h="var(--map-height)"
         m="auto"
-        position="relative"
+        position={{ base: "relative", sm: "static" }}
+        alignItems={{ base: "stretch", sm: "start" }}
+        display={{ base: "block", sm: "flex" }}
       >
-        <Box h="full" overflow="hidden">
-          <Box zIndex="docked" top="0" position="absolute">
-            {currentView === "desktop" ? (
-              <ReportHazards
-                addressHazardData={addressHazardData}
-                isHazardDataLoading={isHazardDataLoading}
-                toggledStates={toggledStates}
-                setToggledStates={setToggledStates}
-                setLayerToggleObj={setLayerToggleObj}
-              />
-            ) : currentView === "mobile" ? (
-              <MobileReportHazards
-                showHazards={showHazards}
-                addressHazardData={addressHazardData}
-                isHazardDataLoading={isHazardDataLoading}
-                toggledStates={toggledStates}
-                setShowHazards={setShowHazards}
-                setToggledStates={setToggledStates}
-                setLayerToggleObj={setLayerToggleObj}
-              />
-            ) : null}
+        {currentView === "desktop" ? (
+          <Box h="full" overflowY={{ base: "visible", sm: "auto" }}>
+            <ReportHazards
+              addressHazardData={addressHazardData}
+              isHazardDataLoading={isHazardDataLoading}
+              toggledStates={toggledStates}
+              setToggledStates={setToggledStates}
+              setLayerToggleObj={setLayerToggleObj}
+            />{" "}
           </Box>
+        ) : currentView === "mobile" ? (
+          <Box zIndex="docked" top="0" position="absolute">
+            <MobileReportHazards
+              showHazards={showHazards}
+              addressHazardData={addressHazardData}
+              isHazardDataLoading={isHazardDataLoading}
+              toggledStates={toggledStates}
+              setShowHazards={setShowHazards}
+              setToggledStates={setToggledStates}
+              setLayerToggleObj={setLayerToggleObj}
+            />
+          </Box>
+        ) : null}
+
+        <Box flex={{ base: "initial", sm: "1" }} h="full">
           <Map
             coordinates={coordinates || defaultCoords}
             softStoryData={softStoryData}

--- a/app/components/card-container.tsx
+++ b/app/components/card-container.tsx
@@ -3,7 +3,7 @@ import { Box, VStack } from "@chakra-ui/react";
 
 export const CardContainer = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Box pt="8" px="8" zIndex="docked" w="full">
+    <Box px="8" py="8" zIndex="docked" w="full">
       <VStack gap="3.5">{children}</VStack>
     </Box>
   );


### PR DESCRIPTION
# Description

This PR is a bandaid for #673. It puts the cards into a scrollable panel with white background. This panel is a sibling of the map instead of overlaying it.

Additionally, we make more of the content below the map visible.

Mobile experience remains unchanged.

Closes #673 

## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test

- open browser and note cards are in their own panel now
- shrink height of browser
- now note that scrollbar appears (in panel) when cards are taller than the map

## Clean commits
- ( ) I plan to Squash and Merge
- (x) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
