### PR TITLE
remove next-env.d.ts entirely and fix reference to it in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Next
 .next
 out
-next-env.d.ts # TODO: look into removing this file from source control entirely
+next-env.d.ts
 
 # Python
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN mkdir -p /app/.next && chown -R node:node /app/.next
 
 USER node
 
-# Copy package*.json, next-env.d.ts, nstall dependencies, as node user
-COPY --chown=node:node ./package*.json next-env.d.ts ./
+# Copy package*.json and install dependencies, as node user
+COPY --chown=node:node ./package*.json ./
 RUN npm install
 
 # Copy the rest of the application, ensuring the ownership is set to node user 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Description

#827 was a swing and a miss. turns out there isn't a way to get .gitignore to ignore a file already in the repo. it's either committed or it's not, no in between as has been suggested and LLMs seem to affirm (yet another reason to not rely on AI summaries without checking sources thoroughly). however, it's my mistake for not testing properly!

this PR thus both removes AND deletes next-env.d.ts which now works since the CI permissions issue was fixed as part of #829.

Closes #781 

## Type of changes
- ( ) Bugfix
- (x) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test

create PR with change to `next-env.d.ts` and it shouldn't show up in `git status`

## Clean commits
- ( ) I plan to Squash and Merge
- (x) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
