### PR TITLE
Allow CI to trigger on branches prefixed with '/ci'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - main
+      - 'ci/**'
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
# Description

Now, CI will trigger automatically on-push if the branch name is prefixed with `/ci`. Previously, only protected branches(`main`, `develop`) had CI trigger on push. Developers would have to create a PR in order to test the CI, which is less convenient.

This change allows developers to test CI **without needing to create a PR.** 

## Type of changes
- ( ) Bugfix
- ( ) Chore
- (X) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## Clean commits
- ( ) I plan to Squash and Merge
- (X) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
