### PR TITLE
workflow to create db scripts

### DIFF
--- a/.github/workflows/dbscripts.yml
+++ b/.github/workflows/dbscripts.yml
@@ -1,8 +1,3 @@
-# TEMPORARY WORKFLOW
-# Purpose: initialize database for CI script development.
-# Do not mark as a required status check.
-# Tracking: https://github.com/sfbrigade/datasci-earthquake/pull/873
-
 name: DB Scripts
 
 on: 

--- a/.github/workflows/dbscripts.yml
+++ b/.github/workflows/dbscripts.yml
@@ -89,12 +89,32 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      
-      - name: Start DB
-        run: docker compose -f compose.yaml -f compose.ci.yaml up -d --wait --wait-timeout 30 db
+      - name: Start Services
+        run: docker compose -f compose.yaml -f compose.ci.yaml up -d --wait --wait-timeout 30 db backend
+
+      # create sql scripts from data in db
+      - run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --data-only --column-inserts -h db -U postgres -f dbscripts/tsunami.sql -t tsunami_zones qsdatabase"
+      - run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --data-only --column-inserts -h db -U postgres -f dbscripts/softstory.sql -t soft_story_properties qsdatabase"
+      - run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --data-only --column-inserts -h db -U postgres -f dbscripts/liquefaction.sql -t liquefaction_zones qsdatabase"
+
+      - run: echo 'verify counts' && docker compose exec -e PGPASSWORD=password -T db sh -c "psql -f verify.sql postgresql://postgres:password@db:5432/qsdatabase" 
+
+      # copy db scripts to runner 
+      - run: docker cp my_postgis_db:dbscripts dbscripts
+
+      # preview scripts 
+      - run: cat dbscripts/tsunami.sql
+      - run: cat dbscripts/softstory.sql
+      - run: cat dbscripts/liquefaction.sql
+
+      - name: upload db scripts
+        uses: actions/upload-artifact@v4
+        with: 
+          name: dbscripts
+          path: dbscripts
 
       - name: Docker DB Logs 
         run: docker logs my_postgis_db 
       
       - name: Clean Up
-        run: docker compose -f compose.yaml -f compose.ci.yaml down db
+        run: docker compose -f compose.yaml -f compose.ci.yaml down backend db

--- a/.github/workflows/dbscripts.yml
+++ b/.github/workflows/dbscripts.yml
@@ -5,34 +5,13 @@
 
 name: DB Scripts
 
-on: workflow_dispatch
+on: 
+  schedule:
+    - cron: "0 0 1,15 * *" # run it on the 1st and 15th of each month at midnight
+  workflow_dispatch:
   
 jobs:
   
-  black_lint_and_mypy_type_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install uv
-        run: |
-          curl -sSL https://astral.sh/uv/install.sh | sh
-          
-      - name: Install dependencies with uv
-        run: |
-          uv pip install --system black==24.10.0 mypy
-          uv pip install --system fastapi pydantic pydantic-settings sqlalchemy GeoAlchemy2 pytest
-
-      - name: Check code formatting with black
-        run: black --check .
-
-      - name: Type check with mypy
-        run: mypy --config-file mypy.ini .
-
   db_scripts:
     runs-on: ubuntu-latest
     steps:
@@ -90,22 +69,31 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Start Services
-        run: docker compose -f compose.yaml -f compose.ci.yaml up -d --wait --wait-timeout 30 db backend
+        run: docker compose -f compose.yaml -f compose.ci.yaml up -d --wait --wait-timeout 60 db backend
 
-      # create sql scripts from data in db
-      - run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --data-only --column-inserts -h db -U postgres -f dbscripts/tsunami.sql -t tsunami_zones qsdatabase"
-      - run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --data-only --column-inserts -h db -U postgres -f dbscripts/softstory.sql -t soft_story_properties qsdatabase"
-      - run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --data-only --column-inserts -h db -U postgres -f dbscripts/liquefaction.sql -t liquefaction_zones qsdatabase"
+      - name: create tsunami.sql 
+        run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --column-inserts -h db -U postgres -f dbscripts/tsunami.sql -t tsunami_zones qsdatabase" 
 
-      - run: echo 'verify counts' && docker compose exec -e PGPASSWORD=password -T db sh -c "psql -f verify.sql postgresql://postgres:password@db:5432/qsdatabase" 
+      - name: create softstory.sql 
+        run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --column-inserts -h db -U postgres -f dbscripts/softstory.sql -t soft_story_properties qsdatabase" 
 
-      # copy db scripts to runner 
-      - run: docker cp my_postgis_db:dbscripts dbscripts
+      - name: create liquefaction.sql 
+        run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --column-inserts -h db -U postgres -f dbscripts/liquefaction.sql -t liquefaction_zones qsdatabase" 
 
-      # preview scripts 
-      - run: cat dbscripts/tsunami.sql
-      - run: cat dbscripts/softstory.sql
-      - run: cat dbscripts/liquefaction.sql
+      - name: verify counts and schemas
+        run: docker compose exec -e PGPASSWORD=password -T db sh -c "psql -f verify.sql postgresql://postgres:password@db:5432/qsdatabase" 
+
+      - name: copy db scripts to runner  
+        run: docker cp my_postgis_db:dbscripts dbscripts 
+
+      - name: preview tsunami.sql  
+        run: cat dbscripts/tsunami.sql 
+
+      - name: preview softstory.sql  
+        run: cat dbscripts/softstory.sql 
+
+      - name: preview liquefaction.sql  
+        run: cat dbscripts/liquefaction.sql 
 
       - name: upload db scripts
         uses: actions/upload-artifact@v4
@@ -114,7 +102,12 @@ jobs:
           path: dbscripts
 
       - name: Docker DB Logs 
+        if: always()
         run: docker logs my_postgis_db 
+      
+      - name: Docker Backend Logs 
+        if: always()
+        run: docker logs datasci-earthquake-backend-1
       
       - name: Clean Up
         run: docker compose -f compose.yaml -f compose.ci.yaml down backend db

--- a/backend/database/Dockerfile
+++ b/backend/database/Dockerfile
@@ -14,9 +14,14 @@ RUN apt-get update \
 COPY initdb-postgis.sh /docker-entrypoint-initdb.d/
 COPY update-postgis.sh /docker-entrypoint-initdb.d/
 
+# verify row counts from ETL; only used in the "dbscripts" workflow
+COPY verify.sql .
+
 # Make init scripts executable
 RUN chmod +x /docker-entrypoint-initdb.d/initdb-postgis.sh \
     && chmod +x /docker-entrypoint-initdb.d/update-postgis.sh
+
+RUN mkdir dbscripts
 
 # Expose the default Postgres port
 EXPOSE 5432

--- a/backend/database/verify.sql
+++ b/backend/database/verify.sql
@@ -1,3 +1,13 @@
 select count(*) as liq from liquefaction_zones;
 select count(*) as soft from soft_story_properties;
 select count(*) as tsu from tsunami_zones;
+
+-- table schemas
+select table_name, column_name, data_type from information_schema.columns where table_name = 'liquefaction_zones';
+select table_name, column_name, data_type from information_schema.columns where table_name = 'soft_story_properties';
+select table_name, column_name, data_type from information_schema.columns where table_name = 'tsunami_zones';
+
+-- keys
+select table_name, column_name, constraint_name from information_schema.key_column_usage where table_name = 'liquefaction_zones';
+select table_name, column_name, constraint_name from information_schema.key_column_usage where table_name = 'soft_story_properties';
+select table_name, column_name, constraint_name from information_schema.key_column_usage where table_name = 'tsunami_zones';

--- a/backend/database/verify.sql
+++ b/backend/database/verify.sql
@@ -1,0 +1,3 @@
+select count(*) as liq from liquefaction_zones;
+select count(*) as soft from soft_story_properties;
+select count(*) as tsu from tsunami_zones;


### PR DESCRIPTION
# Description
created a new workflow to create db scripts to be used for initializing the db with real data (as opposed to dummy data). the workflow uploads these scripts for the the ci workflow to download.  because the data / schemas don't change often, i've scheduled this workflow to run only twice a month. however, if someone needs to work with the latest and greatest, the workflow does allow for manual triggering.

goal: since the etl will eventually be removed from the ci workflow, we need to populate the db with something for the tests to run, and this PR is a first step in that effort.

## Type of changes
- ( ) Bugfix
- ( ) Chore
- (x) New Feature

