### PR TITLE
Update Docker compose wait timeout to 120 seconds

### DIFF
--- a/.github/workflows/dbscripts.yml
+++ b/.github/workflows/dbscripts.yml
@@ -64,7 +64,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Start Services
-        run: docker compose -f compose.yaml -f compose.ci.yaml up -d --wait --wait-timeout 60 db backend
+        run: docker compose -f compose.yaml -f compose.ci.yaml up -d --wait --wait-timeout 120 db backend
 
       - name: create tsunami.sql 
         run: docker compose exec -e PGPASSWORD=password -T db sh -c "pg_dump --column-inserts -h db -U postgres -f dbscripts/tsunami.sql -t tsunami_zones qsdatabase" 


### PR DESCRIPTION
# Description

Increased wait timeout for Docker services to 120 seconds.

The job failed at first due to the application not being 'healthy' after 60 seconds. Increasing this threshold to 120 seconds should prevent premature failure on slower runs.

Follows up on #883 

## Type of changes
- (X) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

1. Go to `Actions`
2. Click the `Db Scripts` workflow on the left sidebar
3. Click the `Run Workflow` dropdown, then run the workflow from the `develop` branch.
4. Confirm that the job runs properly and returns the `dbscripts` artifact on completion

## Clean commits
- ( ) I plan to Squash and Merge
- (X) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
