### PR TITLE
optimize ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           fi
 
   eslint:
-    if: needs.changes.outputs.code_changed == 'true'
+    if: needs.changes.outputs.code_changed == 'trueh'
     runs-on: ubuntu-latest
     needs: changes
     steps:
@@ -67,7 +67,7 @@ jobs:
         run: npm run lint
 
   black_lint_and_mypy_type_check:
-    if: needs.changes.outputs.code_changed == 'true'
+    if: needs.changes.outputs.code_changed == 'trueh'
     runs-on: ubuntu-latest
     needs: changes
     steps:
@@ -88,7 +88,7 @@ jobs:
         run: mypy --config-file mypy.ini .
 
   nextjs_build_check:
-    if: needs.changes.outputs.code_changed == 'true'
+    if: needs.changes.outputs.code_changed == 'trueh'
     runs-on: ubuntu-latest
     needs: changes
     env:
@@ -106,6 +106,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     steps:
+      - uses: actions/setup-node@v6
+        with:
+          cache: 'npm'
+
+      - name: Cache npm dependencies
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: npm-deps-${{ hashFiles('package-lock.json') }}
+
+      - run: npm install
+
       - name: Checkout Code
         uses: actions/checkout@v4
 
@@ -157,19 +169,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Build Docker Containers
         run: docker compose -f compose.yaml -f compose.ci.yaml build
 
       - name: Start Services
-        run: docker compose -f compose.yaml -f compose.ci.yaml up -d --wait --wait-timeout 300
+        run: docker compose -f compose.yaml -f compose.ci.yaml up --no-build -d --wait --wait-timeout 300 db db_test backend
+
+      - name: Start Frontend 
+        run: docker run -d --env-file .env --name my_frontend --mount type=bind,src=./node_modules,dst=/app/node_modules datasci-earthquake-frontend
 
       - name: Docker Backend Logs
         if: always()
@@ -185,13 +192,16 @@ jobs:
 
       - name: Docker Frontend Logs
         if: always()
-        run: docker logs datasci-earthquake-frontend-1 || echo "No logs found"
+        run: docker logs my_frontend || echo "No logs found"
 
-      - name: Run Backend Tests
-        run: docker compose -f compose.yaml -f compose.ci.yaml run --rm backend pytest backend -v
+      #- name: Run Backend Tests
+      #  run: docker compose -f compose.yaml -f compose.ci.yaml run --rm backend pytest backend -v
 
-      - name: Run Frontend Tests
-        run: docker compose -f compose.yaml -f compose.ci.yaml run --rm frontend npm test
+      #- name: Run Frontend Tests
+      #  run: docker compose -f compose.yaml -f compose.ci.yaml run --rm frontend npm test
+
+      - name: Clean Up - Frontend
+        run: docker stop my_frontend
 
       - name: Clean Up
-        run: docker compose -f compose.yaml -f compose.ci.yaml down
+        run: docker compose -f compose.yaml -f compose.ci.yaml down backend db_test db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           fi
 
   eslint:
-    if: needs.changes.outputs.code_changed == 'truep'
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     needs: changes
     steps:
@@ -67,7 +67,7 @@ jobs:
         run: npm run lint
 
   black_lint_and_mypy_type_check:
-    if: needs.changes.outputs.code_changed == 'truep'
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     needs: changes
     steps:
@@ -88,7 +88,7 @@ jobs:
         run: mypy --config-file mypy.ini .
 
   nextjs_build_check:
-    if: needs.changes.outputs.code_changed == 'truep'
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     needs: changes
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           fi
 
   eslint:
-    if: needs.changes.outputs.code_changed == 'trueh'
+    if: needs.changes.outputs.code_changed == 'truep'
     runs-on: ubuntu-latest
     needs: changes
     steps:
@@ -67,7 +67,7 @@ jobs:
         run: npm run lint
 
   black_lint_and_mypy_type_check:
-    if: needs.changes.outputs.code_changed == 'trueh'
+    if: needs.changes.outputs.code_changed == 'truep'
     runs-on: ubuntu-latest
     needs: changes
     steps:
@@ -88,7 +88,7 @@ jobs:
         run: mypy --config-file mypy.ini .
 
   nextjs_build_check:
-    if: needs.changes.outputs.code_changed == 'trueh'
+    if: needs.changes.outputs.code_changed == 'truep'
     runs-on: ubuntu-latest
     needs: changes
     env:
@@ -106,6 +106,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: changes
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
       - uses: actions/setup-node@v6
         with:
           cache: 'npm'
@@ -117,9 +120,6 @@ jobs:
           key: npm-deps-${{ hashFiles('package-lock.json') }}
 
       - run: npm install
-
-      - name: Checkout Code
-        uses: actions/checkout@v4
 
       - name: Set default fork status
         run: echo "is_fork=false" >> $GITHUB_ENV
@@ -173,10 +173,20 @@ jobs:
         run: docker compose -f compose.yaml -f compose.ci.yaml build
 
       - name: Start Services
-        run: docker compose -f compose.yaml -f compose.ci.yaml up --no-build -d --wait --wait-timeout 300 db db_test backend
+        run: docker compose -f compose.yaml -f compose.ci.yaml up --no-build -d --wait --wait-timeout 300 db backend 
 
       - name: Start Frontend 
         run: docker run -d --env-file .env --name my_frontend --mount type=bind,src=./node_modules,dst=/app/node_modules datasci-earthquake-frontend
+
+      - name: Run Backend Tests
+        run: docker compose -f compose.yaml -f compose.ci.yaml run --rm backend pytest backend -v
+
+      - name: Run Frontend Tests
+        run: docker exec --env-file .env my_frontend npm test 
+
+      - name: Docker Frontend Logs
+        if: always()
+        run: docker logs my_frontend || echo "No logs found"
 
       - name: Docker Backend Logs
         if: always()
@@ -186,22 +196,8 @@ jobs:
         if: always()
         run: docker logs my_postgis_db || echo "No logs found"
 
-      - name: Docker DB Test (unit tests) Logs
-        if: always()
-        run: docker logs my_postgis_db_test || echo "No logs found"
-
-      - name: Docker Frontend Logs
-        if: always()
-        run: docker logs my_frontend || echo "No logs found"
-
-      #- name: Run Backend Tests
-      #  run: docker compose -f compose.yaml -f compose.ci.yaml run --rm backend pytest backend -v
-
-      #- name: Run Frontend Tests
-      #  run: docker compose -f compose.yaml -f compose.ci.yaml run --rm frontend npm test
-
       - name: Clean Up - Frontend
         run: docker stop my_frontend
 
       - name: Clean Up
-        run: docker compose -f compose.yaml -f compose.ci.yaml down backend db_test db
+        run: docker compose -f compose.yaml -f compose.ci.yaml down backend db

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ USER node
 
 # Copy package*.json and install dependencies, as node user
 COPY --chown=node:node ./package*.json ./
-RUN npm install
+
+RUN mkdir node_modules
 
 # Copy the rest of the application, ensuring the ownership is set to node user 
 COPY --chown=node:node . ./

--- a/backend/api/tests/test_session_config.py
+++ b/backend/api/tests/test_session_config.py
@@ -11,17 +11,6 @@ from backend.database.session import get_db
 @pytest.fixture(scope="session")
 def test_engine():
     engine = create_engine(settings.database_url_sqlalchemy)
-    print('----------- foster the bananas -------')
-    print(f'test URL = {settings.database_url_sqlalchemy_test}')
-    print(f'reg URL = {settings.database_url_sqlalchemy}')
-    if settings.database_url_sqlalchemy_test.find('@db_test:') != -1:
-        print('foster1: its db_test')
-    else:
-        print('foster1: its NOT db_test')
-    if settings.database_url_sqlalchemy.find('@db:') != -1:
-        print('foster2: its db')
-    else:
-        print('foster2: its NOT db')
     yield engine
 
 

--- a/backend/api/tests/test_session_config.py
+++ b/backend/api/tests/test_session_config.py
@@ -10,7 +10,18 @@ from backend.database.session import get_db
 # Set up a test database engine
 @pytest.fixture(scope="session")
 def test_engine():
-    engine = create_engine(settings.database_url_sqlalchemy_test)
+    engine = create_engine(settings.database_url_sqlalchemy)
+    print('----------- foster the bananas -------')
+    print(f'test URL = {settings.database_url_sqlalchemy_test}')
+    print(f'reg URL = {settings.database_url_sqlalchemy}')
+    if settings.database_url_sqlalchemy_test.find('@db_test:') != -1:
+        print('foster1: its db_test')
+    else:
+        print('foster1: its NOT db_test')
+    if settings.database_url_sqlalchemy.find('@db:') != -1:
+        print('foster2: its db')
+    else:
+        print('foster2: its NOT db')
     yield engine
 
 

--- a/backend/database/Dockerfile
+++ b/backend/database/Dockerfile
@@ -10,14 +10,6 @@ RUN apt-get update \
     postgis postgresql-15-postgis-3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy init scripts if necessary
-COPY initdb-postgis.sh /docker-entrypoint-initdb.d/
-COPY update-postgis.sh /docker-entrypoint-initdb.d/
-
-# Make init scripts executable
-RUN chmod +x /docker-entrypoint-initdb.d/initdb-postgis.sh \
-    && chmod +x /docker-entrypoint-initdb.d/update-postgis.sh
-
 # Expose the default Postgres port
 EXPOSE 5432
 

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -2,13 +2,10 @@
 
 #Dockerfile for next.js
 
-FROM node:24-alpine
+FROM node:24-bookworm-slim
 
 # Must be root to prepare the directories; this command is implied, but being explicit for clarity
 USER root
-
-# Install curl
-RUN apk add --no-cache curl
 
 WORKDIR /app
 
@@ -22,16 +19,10 @@ RUN mkdir -p /app/.next && chown -R node:node /app/.next
 
 USER node
 
-# Copy package*.json and install dependencies, as node user
-COPY --chown=node:node ./package*.json ./
-RUN npm install
-
 # Copy the rest of the application, ensuring the ownership is set to node user 
 COPY --chown=node:node . ./
 
 # Expose the port Next.js runs on during development
 EXPOSE 3000
 
-# Command to run the Next.js app in development mode
-# This command should correspond to the "dev" script in your package.json
-CMD ["npm", "run", "next-dev"]
+CMD npm run next-build && npm run start

--- a/compose.ci.yaml
+++ b/compose.ci.yaml
@@ -6,3 +6,6 @@ services:
       context: . 
       dockerfile: ci.Dockerfile
     volumes: !reset
+  db:
+    volumes: 
+      - ./backend/database:/docker-entrypoint-initdb.d # Mount the SQL scripts directory

--- a/compose.ci.yaml
+++ b/compose.ci.yaml
@@ -2,6 +2,7 @@ services:
   frontend:
     # In CI we do NOT mount the repo into /app, because that can change ownership/permissions
     # and cause Next to fail writing next-env.d.ts or .next.
+    build: 
+      context: . 
+      dockerfile: ci.Dockerfile
     volumes: !reset
-      - /app/node_modules
-      - nextjs_cache:/app/.next

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,6 @@ services:
       - ENVIRONMENT=dev_docker
     volumes:
       - db-data:/var/lib/postgresql/data
-      - ./backend/database:/docker-entrypoint-initdb.d # Mount the SQL scripts directory
     ports:
       - 5432:5432
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -81,6 +81,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: my_frontend
     env_file:
       - .env
     environment:
@@ -91,7 +92,6 @@ services:
       - backend
     volumes:
       - .:/app:rw,delegated # Mount after dependencies are installed
-      - /app/node_modules # This excludes the node_modules from being overwritten
       - nextjs_cache:/app/.next
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000 || exit 1"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,6 +15,7 @@ services:
       - ENVIRONMENT=dev_docker
     volumes:
       - db-data:/var/lib/postgresql/data
+      - ./backend/database:/docker-entrypoint-initdb.d # Mount the SQL scripts directory
     ports:
       - 5432:5432
     healthcheck:
@@ -24,30 +25,6 @@ services:
       timeout: 5s
       retries: 10
       start_period: 30s
-
-  db_test:
-    build:
-      context: ./backend/database
-      dockerfile: Dockerfile
-    container_name: my_postgis_db_test
-    restart: always
-    env_file:
-      - .env
-    environment:
-      - ENVIRONMENT=dev_docker
-    volumes:
-      - ./backend/database:/docker-entrypoint-initdb.d # Mount the SQL scripts directory
-    ports:
-      - 5433:5432
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
-      start_interval: 10s
-      interval: 10s
-      timeout: 5s
-      retries: 10
-      start_period: 30s
-    depends_on:
-      - db
 
   backend:
     build:
@@ -81,7 +58,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: my_frontend
     env_file:
       - .env
     environment:
@@ -92,6 +68,7 @@ services:
       - backend
     volumes:
       - .:/app:rw,delegated # Mount after dependencies are installed
+      - /app/node_modules # This excludes the node_modules from being overwritten
       - nextjs_cache:/app/.next
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:3000 || exit 1"]


### PR DESCRIPTION
# Description

https://github.com/sfbrigade/datasci-earthquake/issues/905

optimize the ci workflow by:
- moving the installation of npm depedencies to the github runner, thus reducing the size of the docker image and reducing the amount of time it takes for CI to complete.  
- removing db_test so all tests should now point to the same db instance.  makes it less confusing, and as an added benefit further reduces the amount of time it takes for CI to complete.