### PR TITLE
improve etl workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,16 @@ jobs:
       - name: Check Next.js production build
         run: npm run build
 
-  docker_build_test:
-    if: needs.changes.outputs.code_changed == 'true'
-    runs-on: ubuntu-latest
+  get-env:
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.changes.outputs.code_changed == 'true'
+    uses: ./.github/workflows/env_vars.yml
     needs: changes
+    secrets: inherit
+
+  docker_build_test:
+    if: always() && needs.changes.outputs.code_changed == 'true' && (needs.get-env.result == 'success' || needs.get-env.result == 'skipped')
+    runs-on: ubuntu-latest
+    needs: [changes, get-env]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -123,23 +129,11 @@ jobs:
         if: env.is_fork == 'true'
         run: cp .env.example .env
 
-      - name: Get Run ID of Most Recent Successful Run
-        if: env.is_fork != 'true'
-        run: |
-          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/sfbrigade/datasci-earthquake/actions/workflows/env_vars.yml/runs?status=completed&conclusion=success")
-          run_id=$(echo "$response" | jq '.workflow_runs[0].id')
-          echo "Run ID: $run_id"
-          echo "run_id=$run_id" >> $GITHUB_ENV
-
       - name: Download .env Artifact
         if: env.is_fork != 'true'
         uses: actions/download-artifact@v4
         with:
           name: encrypted-env-file
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: sfbrigade/datasci-earthquake
-          run-id: ${{ env.run_id }}
 
       - name: Decrypt .env File
         if: env.is_fork != 'true'

--- a/.github/workflows/env_vars.yml
+++ b/.github/workflows/env_vars.yml
@@ -2,11 +2,18 @@ name: Generate .env File
 
 on:
   workflow_dispatch:
+  workflow_call:
+    outputs:
+      env_file_path:
+        description: "Path to encrypted .env file"
+        value: ${{ jobs.create-envfile.outputs.env_file_path }}
 
 jobs:
   create-envfile:
 
     runs-on: ubuntu-latest
+    outputs:
+      env_file_path: .env.enc
 
     steps:
     - name: Make envfile

--- a/.github/workflows/etl_tests.yml
+++ b/.github/workflows/etl_tests.yml
@@ -28,8 +28,15 @@ jobs:
       - name: Type check with mypy
         run: mypy --config-file mypy.ini .
 
+  get-env:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/env_vars.yml
+    secrets: inherit
+
   etl_tests:
     runs-on: ubuntu-latest
+    needs: get-env
+    if: always() && (needs.get-env.result == 'success' || needs.get-env.result == 'skipped')
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -49,24 +56,11 @@ jobs:
         if: env.is_fork == 'true'
         run: cp .env.example .env
 
-      - name: Get Run ID of Most Recent Successful Run
-        id: get_run_id
-        if: env.is_fork != 'true'
-        run: |
-          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/sfbrigade/datasci-earthquake/actions/workflows/env_vars.yml/runs?status=completed&conclusion=success")
-          run_id=$(echo $response | jq '.workflow_runs[0].id')
-          echo "Run ID: $run_id"
-          echo "run_id=$run_id" >> $GITHUB_ENV
-
       - name: Download .env Artifact
         if: env.is_fork != 'true'
         uses: actions/download-artifact@v4
         with:
           name: encrypted-env-file
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: sfbrigade/datasci-earthquake
-          run-id: ${{ env.run_id }}
 
       - name: Decrypt .env File
         if: env.is_fork != 'true'

--- a/.github/workflows/etl_to_neon.yml
+++ b/.github/workflows/etl_to_neon.yml
@@ -7,7 +7,12 @@ on:
   workflow_dispatch:  # Allows manual triggering of the workflow
 
 jobs:
+  get-env:
+    uses: ./.github/workflows/env_vars.yml
+    secrets: inherit
+
   run-etl:
+    needs: get-env
     runs-on: ubuntu-latest  
     outputs:
       changes: ${{ steps.detect_changes.outputs.changes }}    
@@ -35,27 +40,10 @@ jobs:
         run: |
           uv sync --frozen --project backend
 
-      - name: Get Run ID of Most Recent Successful Run
-        id: get_run_id
-        run: |
-          response=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/sfbrigade/datasci-earthquake/actions/workflows/env_vars.yml/runs?status=completed&conclusion=success")
-          run_id=$(echo $response | jq '.workflow_runs[0].id')
-          echo "Run ID: $run_id"
-          echo "run_id=$run_id" >> $GITHUB_ENV     
-
-      - name: Clean and verify .env.enc
-        run: |
-          rm -f .env.enc
-          echo "Removed old .env.enc if present"          
-
       - name: Download .env Artifact 
         uses: actions/download-artifact@v4
         with:
           name: encrypted-env-file
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          repository: sfbrigade/datasci-earthquake
-          run-id: ${{ env.run_id }}    
 
       - name: Decrypt .env File
         run: |


### PR DESCRIPTION
# Description

 Refactored the environment variable generation process into a reusable GitHub Actions workflow. This update replaces the brittle and manual curl + jq API calls previously used to fetch the latest successful .env.enc artifact.

  Key changes:
   - Refactored .github/workflows/env_vars.yml to support workflow_call.
   - Updated etl_to_neon.yml, etl_tests.yml, and ci.yml to utilize the reusable get-env job.
   - Switched to the standard actions/download-artifact@v4 for reliable artifact retrieval.

Original issue: https://github.com/sfbrigade/datasci-earthquake/issues/716

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

 1. Go to the Actions tab in the repository.
 2. Manually trigger the ETL to neon or ETL tests workflow via workflow_dispatch.
 3. Observe the workflow graph to confirm the get-env job runs first.
 4. Verify the run-etl (or equivalent) job successfully downloads and decrypts the .env artifact without API errors.

## Clean commits
- ( ) I plan to Squash and Merge
- (X) My commit history is clean¹

