### PR TITLE
Refactored Dockerfile WORKDIR to avoid redundant manifest copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Replace <service name> with frontend, backend, db, or db_test:
 1. First update code and/or rebuild any containers as necessary. Otherwise you may get false results.
 2. Run the containers (`docker compose up -d)`
 3. Run pytest to test the docker container: `docker exec -it datasci-earthquake-backend-1 pytest backend` or `docker compose exec backend pytest backend`
-4. To get code coverage, run `docker exec -w /backend datasci-earthquake-backend-1 pytest --cov=backend`
+4. To get code coverage, run `docker exec -w /app datasci-earthquake-backend-1 pytest --cov=backend`
 
 ---
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -74,13 +74,18 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+# Ensure Python can resolve backend and api packages regardless of how the container is run
+# (e.g. docker run directly, Railway, CI — not just via compose.yaml)
+ENV PYTHONPATH=/app
+
 # Copy application source code after dependency install for Docker layer caching.
 # Changes to source files won't invalidate the cached dependency layer above.
-COPY api ./api
-COPY backend ./backend
+# --chown ensures appuser owns the files and can write to them (e.g. pytest cache, temp files)
+COPY --chown=appuser:appuser api ./api
+COPY --chown=appuser:appuser backend ./backend
 
 # Copy pytest config so log capture (used by some tests) works inside the container.
-COPY pytest.ini .
+COPY --chown=appuser:appuser pytest.ini .
 
 # Make startup script executable (called by compose.yaml at container start).
 RUN chmod +x ./backend/etl/startup.sh

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
-WORKDIR /
+WORKDIR /app
 
 # Create a non-privileged user that the app will run under.
 ARG UID=1001
@@ -71,12 +71,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Add the virtual environment, created above by uv sync, to PATH 
 # (so Python uses the installed packages)
-ENV VIRTUAL_ENV=/.venv
+ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Copy application source code after dependency install for Docker layer caching.
 # Changes to source files won't invalidate the cached dependency layer above.
-COPY api /api
+COPY api ./api
 COPY backend ./backend
 
 # Copy pytest config so log capture (used by some tests) works inside the container.

--- a/backend/etl/startup.sh
+++ b/backend/etl/startup.sh
@@ -6,7 +6,7 @@ set -o pipefail   # Fail if any command in a pipeline fails
 echo "===== Starting startup.sh ====="
 
 # uv automatically creates a virtual environment called .venv in the backend Dockerfile
-VENV_PYTHON="/.venv/bin/python"
+VENV_PYTHON="/app/.venv/bin/python"
 echo "Using virtual environment python at $VENV_PYTHON"
 
 # Check if the python interpreter exists

--- a/compose.yaml
+++ b/compose.yaml
@@ -56,7 +56,7 @@ services:
     env_file:
       - .env
     environment:
-      - PYTHONPATH=/backend:/
+      - PYTHONPATH=/app/backend:/app
       - DATA_GEOJSON_PATH=/public/data/
       - ENVIRONMENT=dev_docker
     ports:
@@ -65,7 +65,7 @@ services:
       db:
         condition: service_healthy
     volumes:
-      - ./backend:/backend
+      - ./backend:/app/backend
       - ./backend/etl/startup.sh:/startup.sh
       - public_data:/public/data
     command: bash /startup.sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -66,9 +66,8 @@ services:
         condition: service_healthy
     volumes:
       - ./backend:/app/backend
-      - ./backend/etl/startup.sh:/startup.sh
       - public_data:/public/data
-    command: bash /startup.sh
+    command: bash ./backend/etl/startup.sh
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8000/api/health || exit 1"]
       start_interval: 10s

--- a/compose.yaml
+++ b/compose.yaml
@@ -56,7 +56,7 @@ services:
     env_file:
       - .env
     environment:
-      - PYTHONPATH=/app/backend:/app
+      - PYTHONPATH=/app
       - DATA_GEOJSON_PATH=/public/data/
       - ENVIRONMENT=dev_docker
     ports:


### PR DESCRIPTION
# Description

Closes issue #948

Refactors the backend Dockerfile to use the `/app` WORKDIR. Also include refactoring paths of startup and compose files to match this directory.

Result:
The Dockerfile no longer creates duplicate copies of `pyproject.toml` and `uv.lock`.

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

Run the following commands:
- docker compose build --no-cache backend
- docker compose up -d backend
- docker compose exec backend bash

Then, inside the docker container, verify that the old root-level copies no longer exist.
(Run the following 4 commands and confirm that they return `No such file or directory`)
- ls pyproject.toml
- ls /uv.lock
- ls /.venv
- ls /api

Verify that these following copies exist on the /app directory:
- ls /app/pyproject.toml
- ls /app/uv.lock
- ls /app/.venv/bin/python
- ls /app/backend/
- ls /app/api/

## Clean commits
- (X) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
