### PR TITLE
Parallelize ETL Scripts Issue #715

### DIFF
--- a/.github/workflows/etl_to_neon.yml
+++ b/.github/workflows/etl_to_neon.yml
@@ -52,25 +52,21 @@ jobs:
 
       - name: ETL data to Neon DB
         run: |
-          ENVIRONMENT=prod uv run --project backend -m backend.etl.tsunami_data_handler &
+          ENVIRONMENT=prod timeout 20m uv run --project backend -m backend.etl.tsunami_data_handler &
           PID1=$!
-          ENVIRONMENT=prod uv run --project backend -m backend.etl.soft_story_properties_data_handler &
+          ENVIRONMENT=prod timeout 20m uv run --project backend -m backend.etl.soft_story_properties_data_handler &
           PID2=$!
-          ENVIRONMENT=prod uv run --project backend -m backend.etl.liquefaction_data_handler &
+          ENVIRONMENT=prod timeout 20m uv run --project backend -m backend.etl.liquefaction_data_handler &
           PID3=$!
-          ENVIRONMENT=prod uv run --project backend -m backend.etl.landslide_data_handler &
+          ENVIRONMENT=prod timeout 20m uv run --project backend -m backend.etl.landslide_data_handler &
           PID4=$!
-          
-          # Wait for all processes to finish and capture their exit codes
-          wait $PID1 || EXIT_STATUS=$?
-          wait $PID2 || EXIT_STATUS=$?
-          wait $PID3 || EXIT_STATUS=$?
-          wait $PID4 || EXIT_STATUS=$?
-          
-          if [ -n "$EXIT_STATUS" ]; then
-            echo "One or more ETL scripts failed."
-            exit $EXIT_STATUS
-          fi
+
+          FAILED=0
+          wait $PID1 || { echo "tsunami_data_handler failed"; FAILED=1; }
+          wait $PID2 || { echo "soft_story_properties_data_handler failed"; FAILED=1; }
+          wait $PID3 || { echo "liquefaction_data_handler failed"; FAILED=1; }
+          wait $PID4 || { echo "landslide_data_handler failed"; FAILED=1; }
+          [ "$FAILED" -eq 0 ] || exit 1
 
       - name: Commit & Push Changes
         id: detect_changes 

--- a/.github/workflows/etl_to_neon.yml
+++ b/.github/workflows/etl_to_neon.yml
@@ -52,9 +52,25 @@ jobs:
 
       - name: ETL data to Neon DB
         run: |
-          ENVIRONMENT=prod uv run --project backend -m backend.etl.tsunami_data_handler
-          ENVIRONMENT=prod uv run --project backend -m backend.etl.soft_story_properties_data_handler
-          ENVIRONMENT=prod uv run --project backend -m backend.etl.liquefaction_data_handler
+          ENVIRONMENT=prod uv run --project backend -m backend.etl.tsunami_data_handler &
+          PID1=$!
+          ENVIRONMENT=prod uv run --project backend -m backend.etl.soft_story_properties_data_handler &
+          PID2=$!
+          ENVIRONMENT=prod uv run --project backend -m backend.etl.liquefaction_data_handler &
+          PID3=$!
+          ENVIRONMENT=prod uv run --project backend -m backend.etl.landslide_data_handler &
+          PID4=$!
+          
+          # Wait for all processes to finish and capture their exit codes
+          wait $PID1 || EXIT_STATUS=$?
+          wait $PID2 || EXIT_STATUS=$?
+          wait $PID3 || EXIT_STATUS=$?
+          wait $PID4 || EXIT_STATUS=$?
+          
+          if [ -n "$EXIT_STATUS" ]; then
+            echo "One or more ETL scripts failed."
+            exit $EXIT_STATUS
+          fi
 
       - name: Commit & Push Changes
         id: detect_changes 

--- a/backend/etl/landslide_data_handler.py
+++ b/backend/etl/landslide_data_handler.py
@@ -64,6 +64,7 @@ if __name__ == "__main__":
         lanslide_zone_objects, landslide_zone_geojson = handler.parse_data(
             lanslide_zones
         )
+        handler.export_geojson_if_changed(landslide_zone_geojson)
         handler.bulk_insert_data(lanslide_zone_objects, "identifier")
     except HTTPException as e:
         print(f"Failed after retries: {e}")

--- a/backend/etl/landslide_data_handler.py
+++ b/backend/etl/landslide_data_handler.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         lanslide_zone_objects, landslide_zone_geojson = handler.parse_data(
             lanslide_zones
         )
-        handler.export_geojson_if_changed(landslide_zone_geojson)
         handler.bulk_insert_data(lanslide_zone_objects, "identifier")
+        handler.export_geojson_if_changed(landslide_zone_geojson)
     except HTTPException as e:
         print(f"Failed after retries: {e}")


### PR DESCRIPTION
# Description

 Parallelized the execution of the ETL data handlers in the GitHub Actions workflow to significantly reduce total runtime. 
#715 

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (X) I think tests are unnecessary

## How to test

 1. Trigger Workflow: Manually trigger the ETL to neon workflow via
      workflow_dispatch in the Actions tab.
 2. Inspect Logs: Open the "ETL data to Neon DB" step. Verify that logs
    from different handlers (e.g., Tsunami and Landslide) are
    interleaved, confirming parallel execution.
 3. Verify Exit Codes: (Optional) To test error handling, temporarily
    point one handler to an invalid URL and verify that the wait command
    catches the non-zero exit code and fails the GitHub Action.
 4. Check Artifacts: Ensure all four GeoJSON files (TsunamiZone.geojson,
    etc.) are updated and staged for the subsequent PR creation step.

## Clean commits
- ( ) I plan to Squash and Merge
- (X) My commit history is clean¹
