### PR TITLE
hide alert banner on small screens and attempt to autofocus search input

### DIFF
--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -182,7 +182,9 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
         <SHDrawer
           title="Risk Layers"
           footerText={
-            <AlertInfo message="72% chance of major Bay Area earthquake in the next 30 years" />
+            <Box hideBelow="sm">
+              <AlertInfo message="72% chance of major Bay Area earthquake in the next 30 years" />
+            </Box>
           }
         >
           <ReportHazards

--- a/app/components/card-container.tsx
+++ b/app/components/card-container.tsx
@@ -1,5 +1,5 @@
 import React, { Children } from "react";
-import { Box, VStack, Stack, Grid, GridItem } from "@chakra-ui/react";
+import { Box, VStack, Grid, GridItem } from "@chakra-ui/react";
 interface CardContainerProps {
   padded?: boolean;
   stackDirectionResponsive?: boolean;

--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -113,6 +113,7 @@ const SearchBar = ({
             }
           >
             <Input
+              autoFocus
               placeholder="Search San Francisco address"
               fontFamily="body"
               fontSize="md"

--- a/app/components/social-links.tsx
+++ b/app/components/social-links.tsx
@@ -1,6 +1,5 @@
 import { VStack, HStack, IconButton, Text, Flex } from "@chakra-ui/react";
 import { FaInstagram, FaLinkedinIn, FaEnvelope } from "react-icons/fa6";
-import NextLink from "@/components/custom-next-link";
 import NextImage from "next/image";
 
 export function SocialLinks() {


### PR DESCRIPTION
# Description

fix mobile issues, first pass
- hide alert info so more of the hazard card(s) can be seen
- try to focus search input

## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- ( ) I think tests are unnecessary

## How to test

- resize browser to small width or use mobile device to check if alert banner disappears
- check if input search gets focus first

## Clean commits
- (x) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
