### PR TITLE
Reintroduce search bar minimum character/refinement hint as a tooltip

### DIFF
--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -10,6 +10,7 @@ import DynamicAddressAutofill, {
   AddressAutofillRetrieveResponse,
 } from "./address-autofill";
 import { AddressAutofillSuggestionResponse } from "@mapbox/search-js-core";
+import { Tooltip } from "./ui/tooltip";
 
 const autofillOptions: AddressAutofillOptions = {
   country: "US",
@@ -34,13 +35,25 @@ const SearchBar = ({
   onSearchChange,
 }: SearchBarProps) => {
   const [suggestionSelected, setSuggestionSelected] = useState(false);
-  const [suggestionsAvailable, setSuggestionsAvailable] = useState(false);
+  const [suggestionCount, setSuggestionCount] = useState<number | null>(null);
   const router = useRouter();
-  const characterCap = 5;
+  const minimumAutocompleteLength = 3;
+
+  const isBelowAutocompleteMinimum =
+    inputAddress.length < minimumAutocompleteLength;
+  const searchHint = isBelowAutocompleteMinimum
+    ? `Keep typing — enter at least ${minimumAutocompleteLength} characters.`
+    : "Try refining your search.";
+  const showSearchHint = Boolean(
+    inputAddress.length &&
+    !suggestionSelected &&
+    (isBelowAutocompleteMinimum || suggestionCount === 0)
+  );
 
   const handleClearClick = () => {
     onInputAddressChange("");
     setSuggestionSelected(false);
+    setSuggestionCount(null);
     router.push("/", { scroll: false });
   };
 
@@ -60,19 +73,23 @@ const SearchBar = ({
   };
 
   const handleAddressChange = (event: ChangeEvent<HTMLInputElement>) => {
-    onInputAddressChange(event.currentTarget.value);
-    // shows hint again upon further search param changes without selection of suggestion
-    if (!suggestionSelected) setSuggestionsAvailable(false);
-    else if (suggestionSelected && inputAddress.length <= 3) {
+    const nextInputAddress = event.currentTarget.value;
+
+    onInputAddressChange(nextInputAddress);
+    // wait for a response for new value before showing refinement hint
+    setSuggestionCount(null);
+    if (
+      suggestionSelected &&
+      nextInputAddress.length <= minimumAutocompleteLength
+    ) {
       setSuggestionSelected(false);
-      setSuggestionsAvailable(false);
     }
   };
 
   // TODO: consider also capturing/updating address on submit OR using first autocomplete suggestion; see file://./../snippets.md#geocode-on-search for details.
 
   const handleSuggest = (res: AddressAutofillSuggestionResponse) => {
-    setSuggestionsAvailable(res.suggestions.length > 0);
+    setSuggestionCount(res.suggestions.length);
   };
 
   return (
@@ -85,75 +102,74 @@ const SearchBar = ({
           // hides hint when suggestions are provided
           onSuggest={handleSuggest}
         >
-          <InputGroup
-            w={{
-              base: "full",
-              sm: "xs",
-              md: "sm",
+          <Tooltip
+            content={searchHint}
+            open={showSearchHint}
+            openDelay={500}
+            closeDelay={200}
+            showArrow
+            positioning={{
+              placement: "bottom-start",
+              offset: { mainAxis: -12 },
             }}
-            data-testid="search-bar"
-            startElement={
-              <IoSearchSharp
-                color="grey.900"
-                fontSize="1.1em"
-                size="20"
-                data-testid="search-icon"
-              />
-            }
-            endElement={
-              inputAddress.length !== 0 && (
-                <RxCross2
+          >
+            <InputGroup
+              w={{
+                base: "full",
+                sm: "xs",
+                md: "sm",
+              }}
+              data-testid="search-bar"
+              startElement={
+                <IoSearchSharp
                   color="grey.900"
                   fontSize="1.1em"
                   size="20"
-                  data-testid="clear-icon"
-                  onClick={handleClearClick}
+                  data-testid="search-icon"
                 />
-              )
-            }
-          >
-            <Input
-              autoFocus
-              placeholder="Search San Francisco address"
-              fontFamily="body"
-              fontSize="md"
-              size={{ base: "lg", md: "xl", xl: "xl" }}
-              pt="0"
-              pr="2.5"
-              pb="0"
-              pl={{ base: "9", md: "12" }}
-              borderRadius="full"
-              border="search"
-              bgColor="white"
-              shadow="search"
-              type="text"
-              name="address-1"
-              value={inputAddress}
-              onChange={handleAddressChange}
-              _focus={{ borderColor: "yellow" }}
-              _hover={{
-                borderColor: "yellow",
-                _placeholder: { color: "grey.900" },
-              }}
-              _invalid={{ borderColor: "red" }}
-              autoComplete="address-line1"
-            />
-          </InputGroup>
+              }
+              endElement={
+                inputAddress.length !== 0 && (
+                  <RxCross2
+                    color="grey.900"
+                    fontSize="1.1em"
+                    size="20"
+                    data-testid="clear-icon"
+                    onClick={handleClearClick}
+                  />
+                )
+              }
+            >
+              <Input
+                autoFocus
+                placeholder="Search San Francisco address"
+                fontFamily="body"
+                fontSize="md"
+                size={{ base: "lg", md: "xl", xl: "xl" }}
+                pt="0"
+                pr="2.5"
+                pb="0"
+                pl={{ base: "9", md: "12" }}
+                borderRadius="full"
+                border="search"
+                bgColor="white"
+                shadow="search"
+                type="text"
+                name="address-1"
+                value={inputAddress}
+                onChange={handleAddressChange}
+                _focus={{ borderColor: "yellow" }}
+                _hover={{
+                  borderColor: "yellow",
+                  _placeholder: { color: "grey.900" },
+                }}
+                _invalid={{ borderColor: "red" }}
+                autoComplete="address-line1"
+              />
+            </InputGroup>
+          </Tooltip>
         </DynamicAddressAutofill>
       </Suspense>
-      {/* {inputAddress.length && !suggestionSelected && !suggestionsAvailable ? (
-        <Text
-          position="absolute"
-          lineHeight="shortest"
-          textStyle="textSmall"
-          color="white"
-        >
-          {inputAddress.length < characterCap
-            ? "Keep typing…"
-            : "Try refining search…"}
-        </Text>
-      ) : null} */}
-      {/* TODO: restore this code after it gets a design treatment.*/}
     </chakra.form>
   );
 };


### PR DESCRIPTION
# Description

The mobile-first redesign caused some items to go missing. One of those items was the hint for the search bar autocomplete.

If a user typed less than three characters, no autocomplete would be triggered. This could be confusing w/out the hint.

This PR reintroduces search bar minimum character/refinement hint as a tooltip; it also delays appearance of "Refine your search" until # of suggestions comes back (as 0).

## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- ( ) I think tests are unnecessary

## How to test

Expected behavior:
- type in 1 character; note that the tooltip hint to "keep typing" pops up
- type in 2 characters; ""
- type in 3 characters; note that the tooltip hint to "keep typing" disappears
- type in several random characters; note that the tooltip hint to "refine" appears due to 0 results

## Clean commits
- ( ) I plan to Squash and Merge
- (x) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
