### PR TITLE
Disable chakra layers

### DIFF
--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -279,7 +279,7 @@ const globalCss: SystemConfig["globalCss"] = {
     fontFamily: "body", // This applies Inter (the "body" token) globally
   },
   ".chakra-drawer__positioner": {
-    zIndex: "docked !important",
+    zIndex: "docked",
   },
   ".marker": {
     width: "mapMarkerWidth",
@@ -294,16 +294,17 @@ const globalCss: SystemConfig["globalCss"] = {
   // NOTE: !important required to override due to the use of @layer in Chakra UI; alternative is to turn off @layer in Chakra config
   // TODO: consider looking into better workarounds or turning off @layer
   ".mapboxgl-ctrl-group button": {
-    width: "10 !important",
-    height: "10 !important",
+    width: "10",
+    height: "10",
   },
   ".mapboxgl-ctrl-bottom-right": {
-    marginRight: "4 !important",
+    marginRight: "4",
   },
 };
 
 const overridesConfig: SystemConfig = defineConfig({
   preflight: true, // explicitly enable reset styles (AKA preflight styles)
+  disableLayers: true,
   globalCss,
   strictTokens: true,
   theme: {


### PR DESCRIPTION
# Description

Disables Chakra layers to get rid of the `!important` keyword while still preserving the styles. I've added notes inside the issue around my research on the options.

Issue: https://github.com/sfbrigade/datasci-earthquake/issues/977

## Type of changes
- ( ) Bugfix
- (X) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- ( ) I think tests are unnecessary
- (X) Since these are UI changes, I tested by inspecting DOM elements, finding the computed styles, and comparing that against what is expected per the code. I could not see any difference with and without my changes in the UI, but I am open to other suggestions on testing this. 

## How to test

Go to the home page > Ensure that the zoom in and out buttons appear the same size and that the search dropdown is docked

## Clean commits
- ( X) I plan to Squash and Merge (if I add another revision after a review)
- ( X) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
