### PR TITLE
fix to prevent form  submition from search bar

### DIFF
--- a/app/components/search-bar.tsx
+++ b/app/components/search-bar.tsx
@@ -91,9 +91,12 @@ const SearchBar = ({
   const handleSuggest = (res: AddressAutofillSuggestionResponse) => {
     setSuggestionCount(res.suggestions.length);
   };
+  const handleSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault();
+  };
 
   return (
-    <chakra.form position={"relative"}>
+    <chakra.form position={"relative"} onSubmit={handleSubmit}>
       <Suspense>
         <DynamicAddressAutofill
           accessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? ""}


### PR DESCRIPTION
Co-author: Nick Visutsithiwong <2823112+nickvisut@users.noreply.github.com>

# Description

Prevent the form to submit of enter keys or any submit without selecting autocomplete suggestion.

#987 

## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- ( ) I added automated tests
- (x) I think tests are unnecessary

## How to test
Press enter on search bar input box and nothing should happen.

## Clean commits
- (x) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)
