### PR TITLE
Add lightweight feature issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,73 @@
+name: Feature
+description: Propose a product feature or enhancement
+title: ""
+type: Feature
+labels: ["needs triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Start with what you know. Only the problem is required.
+        Other sections can be filled in during refinement.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: >-
+        Who has the problem, what are they trying to do, and what is missing today?
+      placeholder: |
+        When I'm looking at my address's results and see a hazard term I don't
+        recognize, I want to understand what it means so I can judge whether
+        it changes my decision.
+
+        Nothing on the page defines these terms, and the official sources are
+        written for engineers.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired outcome
+      description: >-
+        What should be possible once this problem is solved?
+      placeholder: |
+        Users can understand what "liquefaction" means while interpreting their
+        results, without losing their results context.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: >-
+        Observable conditions that would make this feature successful.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: >-
+        Related work this feature deliberately does not include.
+      placeholder: |
+        - Soft story and tsunami terms — same problem, separate issues
+        - Translation of the explanation
+    validations:
+      required: false
+
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: >-
+        Optional context needed to understand the feature or prior decisions.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- add a structured Feature issue form
- require only the problem at intake
- keep outcome, acceptance criteria, scope, and background optional for refinement
- set the issue type to Feature and apply `needs triage`

## Why
The existing feature request template asks submitters to propose a solution up front. This form keeps intake focused on the problem while allowing the feature to mature during triage and refinement.

## Validation
- form added at `.github/ISSUE_TEMPLATE/feature.yml`
- based on the current protected `develop` head
- live rendering can be verified after merge because GitHub serves issue forms from the default branch