### PR TITLE
Fix search marker hidden under the mobile drawer (#990)

### DIFF
--- a/app/components/__tests__/address-mapper.test.tsx
+++ b/app/components/__tests__/address-mapper.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor, screen } from "@testing-library/react";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import { Provider } from "../ui/provider";
@@ -31,6 +31,7 @@ jest.mock("../map", () => {
     <div
       data-testid="map"
       data-coordinates={JSON.stringify([props.lon, props.lat])}
+      data-bottom-padding-ratio={String(props.bottomPaddingRatio)}
     >
       Mocked Map
     </div>
@@ -83,8 +84,15 @@ const renderAddressMapper = () =>
   );
 
 describe("AddressMapper", () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
   });
 
   it("renders the default map and does not fetch without URL parameters", () => {
@@ -130,6 +138,56 @@ describe("AddressMapper", () => {
 
       expect(reportHazardsElements[0]).toHaveTextContent(
         JSON.stringify(mockData)
+      );
+    });
+  });
+
+  it("passes the mobile drawer ratio to Map and clears it when the drawer closes", async () => {
+    mockSetSearchParams({});
+
+    renderAddressMapper();
+
+    expect(screen.getByTestId("map")).toHaveAttribute(
+      "data-bottom-padding-ratio",
+      "0.5"
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /close risk layers/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("map")).toHaveAttribute(
+        "data-bottom-padding-ratio",
+        "0"
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /open risk layers/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId("map")).toHaveAttribute(
+        "data-bottom-padding-ratio",
+        "0.5"
+      );
+    });
+  });
+
+  it("passes 0 on desktop", async () => {
+    window.matchMedia = jest.fn((query: string) => ({
+      matches: /min-width: (48rem|768px)/.test(query),
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }));
+    mockSetSearchParams({});
+
+    renderAddressMapper();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("map")).toHaveAttribute(
+        "data-bottom-padding-ratio",
+        "0"
       );
     });
   });

--- a/app/components/__tests__/map.test.tsx
+++ b/app/components/__tests__/map.test.tsx
@@ -10,7 +10,10 @@ const mockMapInstance = {
   addControl: jest.fn(),
   on: jest.fn(),
   getCenter: jest.fn(() => ({ lng: 0, lat: 0 })),
-  panTo: jest.fn(),
+  setPadding: jest.fn(),
+  getPadding: jest.fn(() => ({ top: 0, right: 0, bottom: 0, left: 0 })),
+  easeTo: jest.fn(),
+  loaded: jest.fn(() => false),
   resize: jest.fn(),
   getLayer: jest.fn(),
   setLayoutProperty: jest.fn(),
@@ -50,7 +53,7 @@ const fc = {
   features: [],
 };
 
-const renderMap = () =>
+const renderMap = (bottomPaddingRatio = 0) =>
   render(
     <Provider>
       <Map
@@ -61,6 +64,7 @@ const renderMap = () =>
         tsunamiData={fc}
         liquefactionData={fc}
         layerToggleObj={{ layerId: "", toggleState: true }}
+        bottomPaddingRatio={bottomPaddingRatio}
       />
     </Provider>
   );
@@ -70,11 +74,20 @@ describe("Map", () => {
   let mockObserve: jest.Mock;
   let mockDisconnect: jest.Mock;
   let originalResizeObserver: typeof window.ResizeObserver;
+  let originalClientHeight: PropertyDescriptor | undefined;
 
   beforeEach(() => {
     process.env.NEXT_PUBLIC_MAPBOX_TOKEN = "test";
     jest.clearAllMocks();
     originalResizeObserver = window.ResizeObserver;
+    originalClientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight"
+    );
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get: () => 800,
+    });
     mockObserve = jest.fn();
     mockDisconnect = jest.fn();
 
@@ -91,6 +104,15 @@ describe("Map", () => {
 
   afterEach(() => {
     window.ResizeObserver = originalResizeObserver;
+    if (originalClientHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "clientHeight",
+        originalClientHeight
+      );
+    } else {
+      delete (HTMLElement.prototype as { clientHeight?: number }).clientHeight;
+    }
   });
 
   it("observes the map container on mount", () => {
@@ -116,5 +138,56 @@ describe("Map", () => {
     unmount();
 
     expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets bottom padding from the container height on mount", () => {
+    renderMap(0.5);
+
+    expect(mockMapInstance.setPadding).toHaveBeenCalledWith({ bottom: 400 });
+  });
+
+  it("resizes and reapplies bottom padding when the container changes size", () => {
+    renderMap(0.5);
+    mockMapInstance.resize.mockClear();
+    mockMapInstance.setPadding.mockClear();
+
+    act(() => {
+      mockResizeObserverCallback([], {} as ResizeObserver);
+    });
+
+    expect(mockMapInstance.resize).toHaveBeenCalledTimes(1);
+    expect(mockMapInstance.setPadding).toHaveBeenCalledWith({ bottom: 400 });
+  });
+
+  it("pans with bottom padding when coordinates change", () => {
+    const { rerender } = renderMap(0.5);
+
+    rerender(
+      <Provider>
+        <Map
+          lon={-122.5}
+          lat={37.7}
+          address="123 Main St"
+          softStoryData={fc}
+          tsunamiData={fc}
+          liquefactionData={fc}
+          layerToggleObj={{ layerId: "", toggleState: true }}
+          bottomPaddingRatio={0.5}
+        />
+      </Provider>
+    );
+
+    expect(mockMapInstance.easeTo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        padding: { bottom: 400 },
+        duration: 750,
+      })
+    );
+  });
+
+  it("sets zero bottom padding on mount", () => {
+    renderMap(0);
+
+    expect(mockMapInstance.setPadding).toHaveBeenCalledWith({ bottom: 0 });
   });
 });

--- a/app/components/__tests__/map.test.tsx
+++ b/app/components/__tests__/map.test.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Provider } from "../ui/provider";
+import Map from "../map";
+
+const mockMapInstance = {
+  touchZoomRotate: { disableRotation: jest.fn() },
+  addControl: jest.fn(),
+  on: jest.fn(),
+  getCenter: jest.fn(() => ({ lng: 0, lat: 0 })),
+  panTo: jest.fn(),
+  resize: jest.fn(),
+  getLayer: jest.fn(),
+  setLayoutProperty: jest.fn(),
+};
+
+jest.mock("mapbox-gl", () => {
+  const Map = jest.fn(() => mockMapInstance);
+  const Marker = jest.fn(() => ({
+    setLngLat: jest.fn().mockReturnThis(),
+    addTo: jest.fn().mockReturnThis(),
+    remove: jest.fn(),
+  }));
+  class LngLat {
+    constructor(
+      public lng: number,
+      public lat: number
+    ) {}
+  }
+  const NavigationControl = jest.fn();
+
+  return {
+    __esModule: true,
+    default: { Map, Marker, NavigationControl, accessToken: "" },
+    LngLat,
+  };
+});
+
+jest.mock("@/components/ui/toaster", () => ({
+  toaster: {
+    create: jest.fn(),
+    isVisible: jest.fn(() => false),
+  },
+}));
+
+const fc = {
+  type: "FeatureCollection" as const,
+  features: [],
+};
+
+const renderMap = () =>
+  render(
+    <Provider>
+      <Map
+        lon={-122.4}
+        lat={37.8}
+        address="123 Main St"
+        softStoryData={fc}
+        tsunamiData={fc}
+        liquefactionData={fc}
+        layerToggleObj={{ layerId: "", toggleState: true }}
+      />
+    </Provider>
+  );
+
+describe("Map", () => {
+  let mockResizeObserverCallback: ResizeObserverCallback;
+  let mockObserve: jest.Mock;
+  let mockDisconnect: jest.Mock;
+  let originalResizeObserver: typeof window.ResizeObserver;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_MAPBOX_TOKEN = "test";
+    jest.clearAllMocks();
+    originalResizeObserver = window.ResizeObserver;
+    mockObserve = jest.fn();
+    mockDisconnect = jest.fn();
+
+    window.ResizeObserver = class implements ResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        mockResizeObserverCallback = callback;
+      }
+
+      observe = mockObserve;
+      unobserve = jest.fn();
+      disconnect = mockDisconnect;
+    };
+  });
+
+  afterEach(() => {
+    window.ResizeObserver = originalResizeObserver;
+  });
+
+  it("observes the map container on mount", () => {
+    renderMap();
+
+    expect(mockObserve).toHaveBeenCalledTimes(1);
+    expect(mockObserve).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it("resizes the map when the container changes size", () => {
+    renderMap();
+
+    act(() => {
+      mockResizeObserverCallback([], {} as ResizeObserver);
+    });
+
+    expect(mockMapInstance.resize).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnects the observer on unmount", () => {
+    const { unmount } = renderMap();
+
+    unmount();
+
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/address-mapper.tsx
+++ b/app/components/address-mapper.tsx
@@ -2,14 +2,20 @@
 
 import { useEffect, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
-import { Box, Button, HStack, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  HStack,
+  Text,
+  useBreakpointValue,
+} from "@chakra-ui/react";
 import { FeatureCollection, Geometry } from "geojson";
 
 import { toaster } from "@/components/ui/toaster";
 import Map from "./map";
 import ReportHazards from "./report-hazards";
 import { useHazardDataFetcher } from "../hooks/useHazardDataFetcher";
-import SHDrawer from "./drawer";
+import SHDrawer, { MOBILE_DRAWER_HEIGHT_RATIO } from "./drawer";
 import AlertInfo from "./ui/alert-info";
 import NextLink from "@/components/custom-next-link";
 import { useMapState } from "./map-state-provider";
@@ -68,6 +74,10 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
   const displayData = validParams ? addressHazardData : {};
 
   const [isHazardDataLoading, setHazardDataLoading] = useState(false);
+  const [isDrawerOpen, setDrawerOpen] = useState(true);
+  const isMobile = useBreakpointValue({ base: true, md: false }) ?? true;
+  const bottomPaddingRatio =
+    isMobile && isDrawerOpen ? MOBILE_DRAWER_HEIGHT_RATIO : 0;
 
   const [toggledStates, setToggledStates] = useState<boolean[]>(
     toggledStatesDefaults
@@ -180,6 +190,8 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
     <Box w="full" h="full" m="auto" position="relative">
       <Box h="full" overflow="hidden">
         <SHDrawer
+          open={isDrawerOpen}
+          onOpenChange={setDrawerOpen}
           title="Risk Layers"
           footerText={
             <Box hideBelow="sm">
@@ -217,6 +229,7 @@ const AddressMapper: React.FC<AddressMapperProps> = ({
           tsunamiData={tsunamiData}
           liquefactionData={liquefactionData}
           layerToggleObj={layerToggleObj}
+          bottomPaddingRatio={bottomPaddingRatio}
         />
       </Box>
     </Box>

--- a/app/components/drawer.tsx
+++ b/app/components/drawer.tsx
@@ -1,27 +1,29 @@
 "use client";
 
 import React, { useCallback, useRef, useState } from "react";
-import {
-  Box,
-  chakra,
-  Drawer,
-  IconButton,
-  Portal,
-  useDisclosure,
-} from "@chakra-ui/react";
+import { Box, chakra, Drawer, IconButton, Portal } from "@chakra-ui/react";
 import { FaAngleLeft, FaAngleRight } from "react-icons/fa";
 const AngleLeft = chakra(FaAngleLeft);
 const AngleRight = chakra(FaAngleRight);
+
+// Must match the `h={{ base: "1/2" }}` token on `Drawer.Content`.
+export const MOBILE_DRAWER_HEIGHT_RATIO = 0.5;
 
 interface DrawerProps {
   children: React.ReactNode;
   title: string;
   footerText: React.ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
-const SHDrawer = ({ children, title, footerText }: DrawerProps) => {
-  // Drawer
-  const { open, onOpen, onClose } = useDisclosure({ defaultOpen: true });
+const SHDrawer = ({
+  children,
+  title,
+  footerText,
+  open,
+  onOpenChange,
+}: DrawerProps) => {
   const drawerContainerRef = useRef<HTMLDivElement>(null);
   const [drawerContainer, setDrawerContainer] = useState<HTMLDivElement | null>(
     null
@@ -49,7 +51,7 @@ const SHDrawer = ({ children, title, footerText }: DrawerProps) => {
               backgroundColor="white"
             >
               <Box
-                onClick={onOpen}
+                onClick={() => onOpenChange(true)}
                 asChild
                 position="absolute"
                 // Mobile: center horizontally at bottom.
@@ -62,7 +64,12 @@ const SHDrawer = ({ children, title, footerText }: DrawerProps) => {
                 mx={{ base: "auto", md: "0" }}
                 transform={{ base: "none", md: "translateY(-50%)" }}
               >
-                <IconButton variant="subtle" rounded="full" size="md">
+                <IconButton
+                  aria-label="Open risk layers"
+                  variant="subtle"
+                  rounded="full"
+                  size="md"
+                >
                   <AngleRight rotate={{ base: "270deg", md: "0deg" }} />
                 </IconButton>
               </Box>
@@ -74,9 +81,7 @@ const SHDrawer = ({ children, title, footerText }: DrawerProps) => {
           <Drawer.Root
             placement={{ mdDown: "bottom", md: "start" }}
             open={open}
-            onOpenChange={(details) => {
-              if (!details.open) onClose();
-            }}
+            onOpenChange={(details) => onOpenChange(details.open)}
             modal={false}
             closeOnInteractOutside={false}
             lazyMount
@@ -92,6 +97,7 @@ const SHDrawer = ({ children, title, footerText }: DrawerProps) => {
                   // NOTE: the following props are used because the `size` prop values of `Drawer.Root` are too limited (and do not directly correspond to the theme `sizes` tokens)
                   w={{ base: "full", md: "sm" }}
                   maxW={{ base: "full", md: "sm" }}
+                  // Must match `MOBILE_DRAWER_HEIGHT_RATIO`.
                   h={{ base: "1/2", md: "full" }}
                   maxH={{ base: "1/2", md: "full" }}
                   pointerEvents="auto"
@@ -100,7 +106,7 @@ const SHDrawer = ({ children, title, footerText }: DrawerProps) => {
                   }}
                 >
                   <Drawer.CloseTrigger
-                    onClick={onClose}
+                    onClick={() => onOpenChange(false)}
                     asChild
                     position="absolute"
                     // Mobile: centered above drawer edge.
@@ -112,7 +118,12 @@ const SHDrawer = ({ children, title, footerText }: DrawerProps) => {
                     mx={{ base: "auto", md: "0" }}
                     transform={{ base: "none", md: "translateY(-50%)" }}
                   >
-                    <IconButton variant="subtle" rounded="full" size="md">
+                    <IconButton
+                      aria-label="Close risk layers"
+                      variant="subtle"
+                      rounded="full"
+                      size="md"
+                    >
                       <AngleLeft rotate={{ base: "270deg", md: "0deg" }} />
                     </IconButton>
                   </Drawer.CloseTrigger>

--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -36,6 +36,8 @@ interface MapProps {
   tsunamiData: FeatureCollection<Geometry>;
   liquefactionData: FeatureCollection<Geometry>;
   layerToggleObj: LayerToggleObjProps;
+  /** Fraction of the container height covered at the bottom. */
+  bottomPaddingRatio?: number;
 }
 
 const addMarker = (center: LngLat, map: mapboxgl.Map) => {
@@ -58,6 +60,7 @@ const Map: React.FC<MapProps> = ({
   tsunamiData,
   liquefactionData,
   layerToggleObj,
+  bottomPaddingRatio = 0,
 }: MapProps) => {
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<mapboxgl.Map>(null);
@@ -66,6 +69,20 @@ const Map: React.FC<MapProps> = ({
   const toastIdNoToken = "no-token";
   const lastLon = useRef<number | null>(lon);
   const lastLat = useRef<number | null>(lat);
+  const ratioRef = useRef(0);
+  const bottomPaddingPx = (ratio: number) =>
+    Math.round((mapContainerRef.current?.clientHeight ?? 0) * ratio);
+
+  useEffect(() => {
+    ratioRef.current = bottomPaddingRatio;
+    const map = mapRef.current;
+    if (!map) return;
+
+    const bottom = bottomPaddingPx(bottomPaddingRatio);
+    if (map.getPadding().bottom !== bottom) {
+      map.easeTo({ padding: { bottom }, duration: map.loaded() ? 750 : 0 });
+    }
+  }, [bottomPaddingRatio]);
 
   // TODO: how do we simplify this `useEffect()` without ill side effects like map repainting by e.g. breaking it up into multiples or moving anything outside of it? for example, can anything be derived on render instead? or can anything run in a useEffect that runs only in initial render with an empty array w/out complicating subsequent update logic?
   useEffect(() => {
@@ -103,6 +120,7 @@ const Map: React.FC<MapProps> = ({
 
       const nav = new mapboxgl.NavigationControl({ showCompass: false });
       map.addControl(nav, "bottom-right");
+      map.setPadding({ bottom: bottomPaddingPx(ratioRef.current) });
 
       if (center && address) {
         // set up map marker for first time and set its center
@@ -195,7 +213,11 @@ const Map: React.FC<MapProps> = ({
           map.getCenter().lng !== center.lng ||
           map.getCenter().lat !== center.lat
         ) {
-          map.panTo(center, { duration: 750 }); // pan to new center
+          map.easeTo({
+            center,
+            padding: { bottom: bottomPaddingPx(ratioRef.current) },
+            duration: 750,
+          });
           lastLon.current = lon;
           lastLat.current = lat;
         }
@@ -226,7 +248,14 @@ const Map: React.FC<MapProps> = ({
     if (!container || typeof ResizeObserver === "undefined") return;
 
     const observer = new ResizeObserver(() => {
-      mapRef.current?.resize();
+      const map = mapRef.current;
+      if (!map) return;
+
+      map.resize();
+      const bottom = bottomPaddingPx(ratioRef.current);
+      if (map.getPadding().bottom !== bottom) {
+        map.setPadding({ bottom });
+      }
     });
     observer.observe(container);
 

--- a/app/components/map.tsx
+++ b/app/components/map.tsx
@@ -221,6 +221,18 @@ const Map: React.FC<MapProps> = ({
     if (layerToggleObj.layerId != "") handleToggleLayers();
   }, [layerToggleObj]); // re-runs every time state changes
 
+  useEffect(() => {
+    const container = mapContainerRef.current;
+    if (!container || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(() => {
+      mapRef.current?.resize();
+    });
+    observer.observe(container);
+
+    return () => observer.disconnect();
+  }, []);
+
   return <Box ref={mapContainerRef} w="full" h="full" />;
 };
 


### PR DESCRIPTION
# Description

On phones, the search-result marker was centered by the map but ended up under the bottom drawer (see the videos in the issue). Two commits, one root-cause fix and one centering improvement.

**Root cause.** The map is created while the header is 44px shorter than its final height, because the address autofill input is a late-mounting `next/dynamic` import. mapbox-gl 3.18.1 only re-measures its container on window `resize`/`orientationchange`/fullscreen events, so when the input mounts and the map container shrinks, the canvas stays at its old, taller size. Measured on develop: canvas 839px in a 795px container. The map's center is therefore 22px below the visible center, and on mobile that point is under the drawer's top edge (which sits at the visible 50% line). On desktop the drawer is on the left, so the same offset is invisible. Dispatching a synthetic window resize on the live page moved the marker tip from 557px to 535px (drawer top: 534px), confirming the mechanism.

**Commit 1: keep the canvas in sync.** Attach a `ResizeObserver` to the map container and call `map.resize()` on each notification. `map.resize()` is a no-op when the size already matches, so this is cheap.

**Commit 2: center within the visible area.** With the canvas fixed, the marker's tip sits exactly on the drawer's top edge, since the map centers on the whole container while the drawer covers its bottom half. mapbox-gl treats `center` as the center of the *padded* viewport, so the map now gets `padding.bottom` equal to the drawer's share of the container while the drawer is open on mobile:

- `drawer.tsx` becomes controlled (`open` / `onOpenChange`) and exports `MOBILE_DRAWER_HEIGHT_RATIO`, paired with its `h="1/2"` token. The two icon-only buttons gain aria-labels.
- `address-mapper.tsx` owns the drawer state, derives the ratio from `useBreakpointValue({ base: true, md: false })` and drawer state, and passes it to `Map`.
- `map.tsx` applies the padding on creation, on every pan (`easeTo` with `padding`), when the ratio changes (eased, or instant before the style has loaded), and after each observer resize since padding is in pixels.

Desktop is unaffected: the drawer is on the left there, so the ratio is 0.

Closes #990. Tracked by #1015.

Left out on purpose: giving the dynamic autofill import a `loading` placeholder (`SearchBarSkeleton`) to remove the header layout shift that exposed this; the `NavigationControl` at bottom-right also sits under the mobile drawer.

## Type of changes
- (x) Bugfix
- ( ) Chore
- ( ) New Feature

## Testing
- (x) I added automated tests
- ( ) I think tests are unnecessary

- `map.test.tsx` (new): mocks `mapbox-gl` and `ResizeObserver`; checks the container is observed on mount, `resize()` runs when the observer fires, the observer disconnects on unmount, `setPadding` on creation, padding re-applied after an observer resize, `easeTo` with padding on pan, and padding 0 when the ratio is 0.
- `address-mapper.test.tsx`: the Map receives ratio 0.5 on mobile with the drawer open, 0 after closing it, 0.5 after reopening, and 0 on desktop.

## How to test

1. Open the preview at a phone viewport (e.g. iPhone 14 Pro Max) with `/?address=123+Main+St&lon=-122.3945&lat=37.7925`. The marker sits in the middle of the visible map area above the drawer. In the console, `.mapboxgl-canvas` and `.mapboxgl-map` have the same height.
2. Tap the drawer's close button: the marker eases to the vertical center of the full map. Reopen: it returns to the visible half.
3. Search for an address (type three digits, pick a suggestion): the marker lands in the visible half.
4. At desktop width the marker is at the vertical center of the map, as before.

## Clean commits
- (x) I plan to Squash and Merge
- ( ) My commit history is clean¹
  ¹ [_described here_](../blob/develop/README.md#keep-your-commit-history-clean)

Execution: Codex (delegated), reviewed and committed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile map views now adjust bottom padding when the drawer is open.
  * Map positioning responds to container resizing and location changes more smoothly.

* **Bug Fixes**
  * Improved map alignment across mobile and desktop layouts.
  * Drawer state remains synchronized with the surrounding interface.

* **Tests**
  * Expanded coverage for map resizing, padding, panning, drawer behavior, and responsive layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->