### PR TITLE
Add read-only Project iteration rollover dry run

### DIFF
--- a/.github/scripts/project-iteration.mjs
+++ b/.github/scripts/project-iteration.mjs
@@ -1,0 +1,333 @@
+import { pathToFileURL } from 'node:url';
+
+const DEFAULT_ORG = 'sfbrigade';
+const DEFAULT_PROJECT_NUMBER = 13;
+const DEFAULT_TIME_ZONE = 'America/Los_Angeles';
+const API_VERSION = '2026-03-10';
+
+export const STATUS_CATEGORIES = Object.freeze({
+  Backlog: 'backlog',
+  Todo: 'unstarted',
+  Ready: 'unstarted',
+  'In Progress': 'started',
+  'In Review': 'started',
+  Done: 'completed',
+  Canceled: 'canceled',
+  Cancelled: 'canceled',
+});
+
+const ROLLOVER_CATEGORIES = new Set(['unstarted', 'started']);
+const AUTO_ASSIGN_CATEGORIES = new Set(['started']);
+const SPECIAL_TRIAGE_LABEL = 'needs triage';
+
+function rawText(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') return value.raw ?? value.name ?? value.title ?? value.html ?? null;
+  return String(value);
+}
+
+export function addDays(date, days) {
+  const d = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) throw new Error(`Invalid date: ${date}`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export function localDate(timeZone = DEFAULT_TIME_ZONE, now = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(now);
+  const p = Object.fromEntries(parts.map(({ type, value }) => [type, value]));
+  return `${p.year}-${p.month}-${p.day}`;
+}
+
+export function classifyStatus(status, labels = []) {
+  const normalizedLabels = new Set(labels.map((label) => label.toLowerCase()));
+  if (normalizedLabels.has(SPECIAL_TRIAGE_LABEL)) return 'triage';
+  const category = STATUS_CATEGORIES[status];
+  if (!category) throw new Error(`Unknown Status option: ${JSON.stringify(status)}`);
+  return category;
+}
+
+export function decideTransition({ issueState, status, labels = [], iterationRelation, sourceMatches = true }) {
+  if (issueState === 'closed') return { action: 'keep', reason: 'underlying-issue-closed' };
+  const category = classifyStatus(status, labels);
+  if (category === 'triage') return { action: 'keep', reason: 'triage' };
+  if (category === 'completed') return { action: 'keep', reason: 'completed-history' };
+  if (category === 'canceled') return { action: 'keep', reason: 'canceled' };
+  if (category === 'backlog') return { action: 'keep', reason: 'backlog-does-not-roll' };
+  if (iterationRelation === 'future') return { action: 'keep', reason: 'future-scheduling-preserved' };
+  if (iterationRelation === 'current') return { action: 'keep', reason: 'already-current' };
+  if (iterationRelation === 'past' && sourceMatches && ROLLOVER_CATEGORIES.has(category)) {
+    return { action: 'move-current', reason: 'expired-committed-work' };
+  }
+  if (iterationRelation === 'blank' && AUTO_ASSIGN_CATEGORIES.has(category)) {
+    return { action: 'move-current', reason: 'started-work-must-be-current' };
+  }
+  return { action: 'keep', reason: 'no-rule' };
+}
+
+function parseArgs(argv) {
+  const args = {
+    org: process.env.PROJECT_ORG || DEFAULT_ORG,
+    projectNumber: Number(process.env.PROJECT_NUMBER || DEFAULT_PROJECT_NUMBER),
+    timeZone: process.env.PROJECT_TIME_ZONE || DEFAULT_TIME_ZONE,
+    sourceIteration: process.env.SOURCE_ITERATION || null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--org') args.org = argv[++i];
+    else if (arg === '--project-number') args.projectNumber = Number(argv[++i]);
+    else if (arg === '--time-zone') args.timeZone = argv[++i];
+    else if (arg === '--from-iteration') args.sourceIteration = argv[++i];
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!args.org) throw new Error('Organization is required');
+  if (!Number.isInteger(args.projectNumber) || args.projectNumber < 1) throw new Error(`Invalid project number: ${args.projectNumber}`);
+  return args;
+}
+
+function apiHeaders() {
+  return {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': API_VERSION,
+    'User-Agent': 'safehome-project-iteration-dry-run',
+  };
+}
+
+async function githubGetJson(url) {
+  const response = await fetch(url, { headers: apiHeaders() });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub GET ${url} failed: ${response.status} ${body.slice(0, 1000)}`);
+  }
+  return { data: await response.json(), response };
+}
+
+function parseNextLink(link) {
+  if (!link) return null;
+  for (const part of link.split(',')) {
+    const match = part.match(/<([^>]+)>;\s*rel="([^"]+)"/);
+    if (match?.[2] === 'next') return match[1];
+  }
+  return null;
+}
+
+async function getAllPages(initialUrl) {
+  const all = [];
+  let url = initialUrl;
+  while (url) {
+    const { data, response } = await githubGetJson(url);
+    if (!Array.isArray(data)) throw new Error(`Expected array from ${url}; got ${JSON.stringify(data).slice(0, 1500)}`);
+    all.push(...data);
+    url = parseNextLink(response.headers.get('link'));
+  }
+  return all;
+}
+
+function findField(fields, name, dataType) {
+  const matches = fields.filter((field) => field.name === name && (!dataType || field.data_type === dataType));
+  if (matches.length !== 1) throw new Error(`Expected exactly one ${name} field${dataType ? ` (${dataType})` : ''}; found ${matches.length}`);
+  return matches[0];
+}
+
+function normalizeIterations(iterationField) {
+  const configuration = iterationField.configuration;
+  if (!configuration) throw new Error('Iteration field has no configuration');
+  if (configuration.duration !== 14) throw new Error(`Expected 14-day Iterations; field duration is ${configuration.duration}`);
+  const candidates = [
+    ...(configuration.completed_iterations ?? []),
+    ...(configuration.completedIterations ?? []),
+    ...(configuration.iterations ?? []),
+  ];
+  const byId = new Map();
+  for (const iteration of candidates) {
+    const normalized = {
+      id: iteration.id,
+      title: rawText(iteration.title),
+      startDate: iteration.start_date ?? iteration.startDate,
+      duration: iteration.duration ?? configuration.duration,
+    };
+    if (!normalized.id || !normalized.startDate || !normalized.title) continue;
+    byId.set(normalized.id, normalized);
+  }
+  return [...byId.values()].sort((a, b) => a.startDate.localeCompare(b.startDate));
+}
+
+export function resolveIterationState(iterations, today) {
+  const current = iterations.find((iteration) => iteration.startDate <= today && today < addDays(iteration.startDate, iteration.duration));
+  if (!current) throw new Error(`No current Iteration contains ${today}; refusing to guess`);
+  const future = iterations.filter((iteration) => iteration.startDate > current.startDate);
+  return { current, future };
+}
+
+function matchesIterationSelector(iteration, selector) {
+  if (!selector) return true;
+  if (!iteration) return false;
+  const wanted = String(selector).trim().toLowerCase();
+  const title = iteration.title.toLowerCase();
+  return title === wanted || title === `iteration ${wanted}` || iteration.id.toLowerCase() === wanted;
+}
+
+function lookupFieldContainer(item, fieldId) {
+  const containers = [item.field_values, item.fieldValues, item.fields];
+  for (const container of containers) {
+    if (!container) continue;
+    if (Array.isArray(container)) {
+      const match = container.find((value) => String(value.field_id ?? value.fieldId ?? value.field?.id ?? value.id) === String(fieldId));
+      if (match) return match;
+    } else if (typeof container === 'object') {
+      const direct = container[fieldId] ?? container[String(fieldId)];
+      if (direct !== undefined) return direct;
+      const match = Object.values(container).find((value) => value && typeof value === 'object' && String(value.field_id ?? value.fieldId ?? value.field?.id) === String(fieldId));
+      if (match) return match;
+    }
+  }
+  return null;
+}
+
+function iterationIdFromValue(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  return value.iteration_id ?? value.iterationId ?? value.value?.iteration_id ?? value.value?.iterationId ?? value.value ?? null;
+}
+
+function optionIdFromValue(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  return value.option_id ?? value.optionId ?? value.value?.option_id ?? value.value?.optionId ?? value.value ?? null;
+}
+
+function statusNameForItem(item, statusField) {
+  const optionId = optionIdFromValue(lookupFieldContainer(item, statusField.id));
+  if (!optionId) return null;
+  const option = (statusField.options ?? []).find((entry) => entry.id === optionId);
+  return option ? rawText(option.name) : null;
+}
+
+function iterationForItem(item, iterationField, iterationById) {
+  const iterationId = iterationIdFromValue(lookupFieldContainer(item, iterationField.id));
+  return iterationId ? iterationById.get(iterationId) ?? { id: iterationId, title: iterationId } : null;
+}
+
+function itemIssueApiUrl(item) {
+  const content = item.content ?? {};
+  if (typeof content.url === 'string' && /\/repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(content.url)) return content.url;
+  const repositoryUrl = content.repository_url ?? content.repositoryUrl;
+  if (repositoryUrl && content.number) return `${repositoryUrl}/issues/${content.number}`;
+  if (typeof content.html_url === 'string') {
+    const match = content.html_url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)$/);
+    if (match) return `https://api.github.com/repos/${match[1]}/${match[2]}/issues/${match[3]}`;
+  }
+  return null;
+}
+
+function normalizeLabels(labels) {
+  if (!Array.isArray(labels)) return [];
+  return labels.map((label) => (typeof label === 'string' ? label : label?.name)).filter(Boolean).map((label) => label.toLowerCase());
+}
+
+async function issueMetadata(item) {
+  const content = item.content ?? {};
+  if (content.state && Array.isArray(content.labels)) {
+    return { state: content.state, labels: normalizeLabels(content.labels), number: content.number, title: content.title };
+  }
+  const url = itemIssueApiUrl(item);
+  if (!url) return { state: content.state ?? 'unknown', labels: [], number: content.number, title: content.title };
+  const { data } = await githubGetJson(url);
+  return { state: data.state, labels: normalizeLabels(data.labels), number: data.number, title: data.title };
+}
+
+function contentType(item) {
+  return item.content_type ?? item.contentType ?? item.type ?? null;
+}
+
+function relationFor(iteration, current, today) {
+  if (!iteration) return 'blank';
+  if (iteration.id === current.id) return 'current';
+  if (iteration.startDate && iteration.startDate > today) return 'future';
+  if (iteration.startDate && addDays(iteration.startDate, iteration.duration ?? 14) <= today) return 'past';
+  return 'unknown';
+}
+
+function titleForItem(item, metadata) {
+  return metadata.title ?? item.content?.title ?? item.title ?? '(untitled)';
+}
+
+function printResult({ current, future, sourceIteration, moves, keeps, warnings }) {
+  console.log(`CURRENT: ${current.title} (${current.startDate} → ${addDays(current.startDate, current.duration)})`);
+  console.log(`FUTURE ITERATIONS: ${future.length}`);
+  if (sourceIteration) console.log(`SOURCE FILTER: ${sourceIteration}`);
+  console.log('');
+  if (warnings.length) {
+    console.log('WARNINGS');
+    for (const warning of warnings) console.log(`- ${warning}`);
+    console.log('');
+  }
+  console.log('WOULD MOVE');
+  if (!moves.length) console.log('(none)');
+  for (const row of moves) console.log(`#${row.number ?? '?'}  ${row.status}  ${row.from} → ${current.title}  [${row.reason}]  ${row.title}`);
+  console.log('');
+  console.log('WOULD KEEP');
+  if (!keeps.length) console.log('(none)');
+  for (const row of keeps) console.log(`#${row.number ?? '?'}  ${row.status ?? '(no status)'}  ${row.from}  [${row.reason}]  ${row.title}`);
+  console.log('');
+  console.log(`SUMMARY move=${moves.length} keep=${keeps.length} warnings=${warnings.length}`);
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const today = localDate(args.timeZone);
+  const base = `https://api.github.com/orgs/${encodeURIComponent(args.org)}/projectsV2/${args.projectNumber}`;
+  const { data: fields } = await githubGetJson(`${base}/fields?per_page=100`);
+  if (!Array.isArray(fields)) throw new Error('Project fields response was not an array');
+  const statusField = findField(fields, 'Status', 'single_select');
+  const iterationField = findField(fields, 'Iteration', 'iteration');
+  const iterations = normalizeIterations(iterationField);
+  const iterationById = new Map(iterations.map((iteration) => [iteration.id, iteration]));
+  const { current, future } = resolveIterationState(iterations, today);
+  const warnings = [];
+  if (future.length < 3) warnings.push(`Only ${future.length} future Iteration(s) configured; manually keep at least 3 available.`);
+  const fieldIds = `${statusField.id},${iterationField.id}`;
+  const items = await getAllPages(`${base}/items?fields=${encodeURIComponent(fieldIds)}&per_page=100`);
+  const moves = [];
+  const keeps = [];
+  let recognizedFieldShape = false;
+  for (const item of items) {
+    const type = contentType(item);
+    if (type && String(type).toLowerCase() !== 'issue') continue;
+    const status = statusNameForItem(item, statusField);
+    const iteration = iterationForItem(item, iterationField, iterationById);
+    if (lookupFieldContainer(item, statusField.id) || lookupFieldContainer(item, iterationField.id)) recognizedFieldShape = true;
+    if (args.sourceIteration && !matchesIterationSelector(iteration, args.sourceIteration)) continue;
+    if (!args.sourceIteration && !iteration && status && classifyStatus(status, []) !== 'started') continue;
+    const metadata = await issueMetadata(item);
+    const relation = relationFor(iteration, current, today);
+    if (relation === 'unknown') throw new Error(`Cannot classify Iteration relation for item ${item.id ?? item.node_id}`);
+    if (!status) {
+      keeps.push({ number: metadata.number, title: titleForItem(item, metadata), status: null, from: iteration?.title ?? 'none', reason: 'missing-status' });
+      continue;
+    }
+    const decision = decideTransition({ issueState: metadata.state, status, labels: metadata.labels, iterationRelation: relation, sourceMatches: true });
+    const row = { itemId: item.id, number: metadata.number, title: titleForItem(item, metadata), status, from: iteration?.title ?? 'none', reason: decision.reason };
+    if (decision.action === 'move-current') moves.push(row);
+    else keeps.push(row);
+  }
+  if (!recognizedFieldShape && items.length) {
+    const sample = JSON.stringify(items[0], null, 2).slice(0, 8000);
+    throw new Error(`Unrecognized Project item field-value shape. Bounded sample:\n${sample}`);
+  }
+  printResult({ current, future, sourceIteration: args.sourceIteration, moves, keeps, warnings });
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(error.stack ?? error.message ?? String(error));
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/project-iteration.mjs
+++ b/.github/scripts/project-iteration.mjs
@@ -23,8 +23,26 @@ const SPECIAL_TRIAGE_LABEL = 'needs triage';
 function rawText(value) {
   if (value == null) return null;
   if (typeof value === 'string') return value;
-  if (typeof value === 'object') return value.raw ?? value.name ?? value.title ?? value.html ?? null;
-  return String(value);
+  if (typeof value !== 'object') return String(value);
+  for (const candidate of [value.raw, value.name, value.title, value.text, value.html]) {
+    const text = rawText(candidate);
+    if (text != null) return text;
+  }
+  return null;
+}
+
+function scalarId(value, kind) {
+  if (value == null) return null;
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  if (typeof value !== 'object') return null;
+  const candidates = kind === 'iteration'
+    ? [value.iteration_id, value.iterationId, value.iteration?.id, value.id, value.value]
+    : [value.option_id, value.optionId, value.option?.id, value.single_select_option?.id, value.singleSelectOption?.id, value.id, value.value];
+  for (const candidate of candidates) {
+    const id = scalarId(candidate, kind);
+    if (id != null) return id;
+  }
+  return null;
 }
 
 export function addDays(date, days) {
@@ -53,21 +71,32 @@ export function classifyStatus(status, labels = []) {
   return category;
 }
 
-export function decideTransition({ issueState, status, labels = [], iterationRelation, sourceMatches = true }) {
+export function decideTransition({
+  issueState,
+  status,
+  labels = [],
+  iterationRelation,
+  sourceMatches = true,
+}) {
   if (issueState === 'closed') return { action: 'keep', reason: 'underlying-issue-closed' };
+
   const category = classifyStatus(status, labels);
   if (category === 'triage') return { action: 'keep', reason: 'triage' };
   if (category === 'completed') return { action: 'keep', reason: 'completed-history' };
   if (category === 'canceled') return { action: 'keep', reason: 'canceled' };
   if (category === 'backlog') return { action: 'keep', reason: 'backlog-does-not-roll' };
+
   if (iterationRelation === 'future') return { action: 'keep', reason: 'future-scheduling-preserved' };
   if (iterationRelation === 'current') return { action: 'keep', reason: 'already-current' };
+
   if (iterationRelation === 'past' && sourceMatches && ROLLOVER_CATEGORIES.has(category)) {
     return { action: 'move-current', reason: 'expired-committed-work' };
   }
+
   if (iterationRelation === 'blank' && AUTO_ASSIGN_CATEGORIES.has(category)) {
     return { action: 'move-current', reason: 'started-work-must-be-current' };
   }
+
   return { action: 'keep', reason: 'no-rule' };
 }
 
@@ -77,17 +106,23 @@ function parseArgs(argv) {
     projectNumber: Number(process.env.PROJECT_NUMBER || DEFAULT_PROJECT_NUMBER),
     timeZone: process.env.PROJECT_TIME_ZONE || DEFAULT_TIME_ZONE,
     sourceIteration: process.env.SOURCE_ITERATION || null,
+    debug: false,
   };
+
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--org') args.org = argv[++i];
     else if (arg === '--project-number') args.projectNumber = Number(argv[++i]);
     else if (arg === '--time-zone') args.timeZone = argv[++i];
     else if (arg === '--from-iteration') args.sourceIteration = argv[++i];
+    else if (arg === '--debug') args.debug = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
+
   if (!args.org) throw new Error('Organization is required');
-  if (!Number.isInteger(args.projectNumber) || args.projectNumber < 1) throw new Error(`Invalid project number: ${args.projectNumber}`);
+  if (!Number.isInteger(args.projectNumber) || args.projectNumber < 1) {
+    throw new Error(`Invalid project number: ${args.projectNumber}`);
+  }
   return args;
 }
 
@@ -99,12 +134,17 @@ function apiHeaders() {
   };
 }
 
-async function githubGetJson(url) {
+async function githubGet(url) {
   const response = await fetch(url, { headers: apiHeaders() });
   if (!response.ok) {
     const body = await response.text();
     throw new Error(`GitHub GET ${url} failed: ${response.status} ${body.slice(0, 1000)}`);
   }
+  return response;
+}
+
+async function githubGetJson(url) {
+  const response = await githubGet(url);
   return { data: await response.json(), response };
 }
 
@@ -122,7 +162,9 @@ async function getAllPages(initialUrl) {
   let url = initialUrl;
   while (url) {
     const { data, response } = await githubGetJson(url);
-    if (!Array.isArray(data)) throw new Error(`Expected array from ${url}; got ${JSON.stringify(data).slice(0, 1500)}`);
+    if (!Array.isArray(data)) {
+      throw new Error(`Expected array from ${url}; got ${JSON.stringify(data).slice(0, 1500)}`);
+    }
     all.push(...data);
     url = parseNextLink(response.headers.get('link'));
   }
@@ -130,15 +172,24 @@ async function getAllPages(initialUrl) {
 }
 
 function findField(fields, name, dataType) {
-  const matches = fields.filter((field) => field.name === name && (!dataType || field.data_type === dataType));
-  if (matches.length !== 1) throw new Error(`Expected exactly one ${name} field${dataType ? ` (${dataType})` : ''}; found ${matches.length}`);
+  const matches = fields.filter(
+    (field) => field.name === name && (!dataType || field.data_type === dataType),
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one ${name} field${dataType ? ` (${dataType})` : ''}; found ${matches.length}`,
+    );
+  }
   return matches[0];
 }
 
 function normalizeIterations(iterationField) {
   const configuration = iterationField.configuration;
   if (!configuration) throw new Error('Iteration field has no configuration');
-  if (configuration.duration !== 14) throw new Error(`Expected 14-day Iterations; field duration is ${configuration.duration}`);
+  if (configuration.duration !== 14) {
+    throw new Error(`Expected 14-day Iterations; field duration is ${configuration.duration}`);
+  }
+
   const candidates = [
     ...(configuration.completed_iterations ?? []),
     ...(configuration.completedIterations ?? []),
@@ -147,8 +198,8 @@ function normalizeIterations(iterationField) {
   const byId = new Map();
   for (const iteration of candidates) {
     const normalized = {
-      id: iteration.id,
-      title: rawText(iteration.title),
+      id: String(iteration.id),
+      title: rawText(iteration.title) ?? String(iteration.id),
       startDate: iteration.start_date ?? iteration.startDate,
       duration: iteration.duration ?? configuration.duration,
     };
@@ -159,8 +210,11 @@ function normalizeIterations(iterationField) {
 }
 
 export function resolveIterationState(iterations, today) {
-  const current = iterations.find((iteration) => iteration.startDate <= today && today < addDays(iteration.startDate, iteration.duration));
+  const current = iterations.find(
+    (iteration) => iteration.startDate <= today && today < addDays(iteration.startDate, iteration.duration),
+  );
   if (!current) throw new Error(`No current Iteration contains ${today}; refusing to guess`);
+
   const future = iterations.filter((iteration) => iteration.startDate > current.startDate);
   return { current, future };
 }
@@ -169,8 +223,11 @@ function matchesIterationSelector(iteration, selector) {
   if (!selector) return true;
   if (!iteration) return false;
   const wanted = String(selector).trim().toLowerCase();
-  const title = iteration.title.toLowerCase();
-  return title === wanted || title === `iteration ${wanted}` || iteration.id.toLowerCase() === wanted;
+  const title = String(iteration.title).toLowerCase();
+  if (title === wanted) return true;
+  if (title === `iteration ${wanted}`) return true;
+  if (String(iteration.id).toLowerCase() === wanted) return true;
+  return false;
 }
 
 function lookupFieldContainer(item, fieldId) {
@@ -178,12 +235,19 @@ function lookupFieldContainer(item, fieldId) {
   for (const container of containers) {
     if (!container) continue;
     if (Array.isArray(container)) {
-      const match = container.find((value) => String(value.field_id ?? value.fieldId ?? value.field?.id ?? value.id) === String(fieldId));
+      const match = container.find((value) => {
+        const candidate = value.field_id ?? value.fieldId ?? value.field?.id ?? value.id;
+        return String(candidate) === String(fieldId);
+      });
       if (match) return match;
     } else if (typeof container === 'object') {
       const direct = container[fieldId] ?? container[String(fieldId)];
       if (direct !== undefined) return direct;
-      const match = Object.values(container).find((value) => value && typeof value === 'object' && String(value.field_id ?? value.fieldId ?? value.field?.id) === String(fieldId));
+      const match = Object.values(container).find((value) => {
+        if (!value || typeof value !== 'object') return false;
+        const candidate = value.field_id ?? value.fieldId ?? value.field?.id;
+        return String(candidate) === String(fieldId);
+      });
       if (match) return match;
     }
   }
@@ -191,34 +255,45 @@ function lookupFieldContainer(item, fieldId) {
 }
 
 function iterationIdFromValue(value) {
-  if (value == null) return null;
-  if (typeof value === 'string') return value;
-  return value.iteration_id ?? value.iterationId ?? value.value?.iteration_id ?? value.value?.iterationId ?? value.value ?? null;
+  return scalarId(value, 'iteration');
 }
 
 function optionIdFromValue(value) {
-  if (value == null) return null;
-  if (typeof value === 'string') return value;
-  return value.option_id ?? value.optionId ?? value.value?.option_id ?? value.value?.optionId ?? value.value ?? null;
+  return scalarId(value, 'option');
 }
 
 function statusNameForItem(item, statusField) {
-  const optionId = optionIdFromValue(lookupFieldContainer(item, statusField.id));
+  const value = lookupFieldContainer(item, statusField.id);
+  const directName = rawText(value?.name ?? value?.option?.name ?? value?.single_select_option?.name ?? value?.singleSelectOption?.name);
+  if (directName) return directName;
+  const optionId = optionIdFromValue(value);
   if (!optionId) return null;
-  const option = (statusField.options ?? []).find((entry) => entry.id === optionId);
+  const option = (statusField.options ?? []).find((entry) => String(entry.id) === String(optionId));
   return option ? rawText(option.name) : null;
 }
 
 function iterationForItem(item, iterationField, iterationById) {
-  const iterationId = iterationIdFromValue(lookupFieldContainer(item, iterationField.id));
-  return iterationId ? iterationById.get(iterationId) ?? { id: iterationId, title: iterationId } : null;
+  const value = lookupFieldContainer(item, iterationField.id);
+  const iterationId = iterationIdFromValue(value);
+  if (!iterationId) return null;
+  const configured = iterationById.get(String(iterationId));
+  if (configured) return configured;
+  return {
+    id: String(iterationId),
+    title: rawText(value?.title ?? value?.iteration?.title) ?? String(iterationId),
+    startDate: value?.start_date ?? value?.startDate ?? value?.iteration?.start_date ?? value?.iteration?.startDate,
+    duration: value?.duration ?? value?.iteration?.duration ?? 14,
+  };
 }
 
 function itemIssueApiUrl(item) {
   const content = item.content ?? {};
-  if (typeof content.url === 'string' && /\/repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(content.url)) return content.url;
+  if (typeof content.url === 'string' && /\/repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(content.url)) {
+    return content.url;
+  }
   const repositoryUrl = content.repository_url ?? content.repositoryUrl;
-  if (repositoryUrl && content.number) return `${repositoryUrl}/issues/${content.number}`;
+  const number = content.number;
+  if (repositoryUrl && number) return `${repositoryUrl}/issues/${number}`;
   if (typeof content.html_url === 'string') {
     const match = content.html_url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)$/);
     if (match) return `https://api.github.com/repos/${match[1]}/${match[2]}/issues/${match[3]}`;
@@ -228,7 +303,10 @@ function itemIssueApiUrl(item) {
 
 function normalizeLabels(labels) {
   if (!Array.isArray(labels)) return [];
-  return labels.map((label) => (typeof label === 'string' ? label : label?.name)).filter(Boolean).map((label) => label.toLowerCase());
+  return labels
+    .map((label) => (typeof label === 'string' ? label : label?.name))
+    .filter(Boolean)
+    .map((label) => label.toLowerCase());
 }
 
 async function issueMetadata(item) {
@@ -237,7 +315,9 @@ async function issueMetadata(item) {
     return { state: content.state, labels: normalizeLabels(content.labels), number: content.number, title: content.title };
   }
   const url = itemIssueApiUrl(item);
-  if (!url) return { state: content.state ?? 'unknown', labels: [], number: content.number, title: content.title };
+  if (!url) {
+    return { state: content.state ?? 'unknown', labels: [], number: content.number, title: content.title };
+  }
   const { data } = await githubGetJson(url);
   return { state: data.state, labels: normalizeLabels(data.labels), number: data.number, title: data.title };
 }
@@ -263,18 +343,25 @@ function printResult({ current, future, sourceIteration, moves, keeps, warnings 
   console.log(`FUTURE ITERATIONS: ${future.length}`);
   if (sourceIteration) console.log(`SOURCE FILTER: ${sourceIteration}`);
   console.log('');
+
   if (warnings.length) {
     console.log('WARNINGS');
     for (const warning of warnings) console.log(`- ${warning}`);
     console.log('');
   }
+
   console.log('WOULD MOVE');
   if (!moves.length) console.log('(none)');
-  for (const row of moves) console.log(`#${row.number ?? '?'}  ${row.status}  ${row.from} → ${current.title}  [${row.reason}]  ${row.title}`);
+  for (const row of moves) {
+    console.log(`#${row.number ?? '?'}  ${row.status}  ${row.from} → ${current.title}  [${row.reason}]  ${row.title}`);
+  }
   console.log('');
+
   console.log('WOULD KEEP');
   if (!keeps.length) console.log('(none)');
-  for (const row of keeps) console.log(`#${row.number ?? '?'}  ${row.status ?? '(no status)'}  ${row.from}  [${row.reason}]  ${row.title}`);
+  for (const row of keeps) {
+    console.log(`#${row.number ?? '?'}  ${row.status ?? '(no status)'}  ${row.from}  [${row.reason}]  ${row.title}`);
+  }
   console.log('');
   console.log(`SUMMARY move=${moves.length} keep=${keeps.length} warnings=${warnings.length}`);
 }
@@ -283,44 +370,83 @@ export async function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const today = localDate(args.timeZone);
   const base = `https://api.github.com/orgs/${encodeURIComponent(args.org)}/projectsV2/${args.projectNumber}`;
+
   const { data: fields } = await githubGetJson(`${base}/fields?per_page=100`);
   if (!Array.isArray(fields)) throw new Error('Project fields response was not an array');
+
   const statusField = findField(fields, 'Status', 'single_select');
   const iterationField = findField(fields, 'Iteration', 'iteration');
   const iterations = normalizeIterations(iterationField);
   const iterationById = new Map(iterations.map((iteration) => [iteration.id, iteration]));
   const { current, future } = resolveIterationState(iterations, today);
+
   const warnings = [];
-  if (future.length < 3) warnings.push(`Only ${future.length} future Iteration(s) configured; manually keep at least 3 available.`);
+  if (future.length < 3) {
+    warnings.push(`Only ${future.length} future Iteration(s) configured; manually keep at least 3 available.`);
+  }
+
   const fieldIds = `${statusField.id},${iterationField.id}`;
   const items = await getAllPages(`${base}/items?fields=${encodeURIComponent(fieldIds)}&per_page=100`);
+
   const moves = [];
   const keeps = [];
   let recognizedFieldShape = false;
+
   for (const item of items) {
     const type = contentType(item);
     if (type && String(type).toLowerCase() !== 'issue') continue;
+
     const status = statusNameForItem(item, statusField);
     const iteration = iterationForItem(item, iterationField, iterationById);
-    if (lookupFieldContainer(item, statusField.id) || lookupFieldContainer(item, iterationField.id)) recognizedFieldShape = true;
+    if (lookupFieldContainer(item, statusField.id) || lookupFieldContainer(item, iterationField.id)) {
+      recognizedFieldShape = true;
+    }
+
     if (args.sourceIteration && !matchesIterationSelector(iteration, args.sourceIteration)) continue;
     if (!args.sourceIteration && !iteration && status && classifyStatus(status, []) !== 'started') continue;
+
     const metadata = await issueMetadata(item);
     const relation = relationFor(iteration, current, today);
-    if (relation === 'unknown') throw new Error(`Cannot classify Iteration relation for item ${item.id ?? item.node_id}`);
+    if (relation === 'unknown') {
+      throw new Error(`Cannot classify Iteration relation for item ${item.id ?? item.node_id}`);
+    }
+
     if (!status) {
-      keeps.push({ number: metadata.number, title: titleForItem(item, metadata), status: null, from: iteration?.title ?? 'none', reason: 'missing-status' });
+      keeps.push({
+        number: metadata.number,
+        title: titleForItem(item, metadata),
+        status: null,
+        from: iteration?.title ?? 'none',
+        reason: 'missing-status',
+      });
       continue;
     }
-    const decision = decideTransition({ issueState: metadata.state, status, labels: metadata.labels, iterationRelation: relation, sourceMatches: true });
-    const row = { itemId: item.id, number: metadata.number, title: titleForItem(item, metadata), status, from: iteration?.title ?? 'none', reason: decision.reason };
+
+    const decision = decideTransition({
+      issueState: metadata.state,
+      status,
+      labels: metadata.labels,
+      iterationRelation: relation,
+      sourceMatches: true,
+    });
+
+    const row = {
+      itemId: item.id,
+      number: metadata.number,
+      title: titleForItem(item, metadata),
+      status,
+      from: iteration?.title ?? 'none',
+      reason: decision.reason,
+    };
     if (decision.action === 'move-current') moves.push(row);
     else keeps.push(row);
   }
+
   if (!recognizedFieldShape && items.length) {
     const sample = JSON.stringify(items[0], null, 2).slice(0, 8000);
     throw new Error(`Unrecognized Project item field-value shape. Bounded sample:\n${sample}`);
   }
+
   printResult({ current, future, sourceIteration: args.sourceIteration, moves, keeps, warnings });
 }
 

--- a/.github/scripts/project-iteration.mjs
+++ b/.github/scripts/project-iteration.mjs
@@ -142,9 +142,9 @@ function scalarId(value, kind) {
   if (typeof value === 'string' || typeof value === 'number') return String(value);
   if (typeof value !== 'object') return null;
   const candidates = kind === 'iteration'
-    ? [value.iteration_id, value.iterationId, value.iteration?.id, value.id, value.value]
+    ? [value.iteration_id, value.iterationId, value.iteration?.id, value.value?.id]
     : [value.option_id, value.optionId, value.option?.id, value.single_select_option?.id,
-      value.singleSelectOption?.id, value.id, value.value];
+      value.singleSelectOption?.id, value.value?.id];
   for (const candidate of candidates) {
     const id = scalarId(candidate, kind);
     if (id != null) return id;
@@ -202,10 +202,11 @@ function fieldValue(item, fieldId) {
 }
 
 function statusName(item, statusField) {
-  const value = fieldValue(item, statusField.id);
-  const direct = rawText(value?.name ?? value?.option?.name ?? value?.single_select_option?.name ?? value?.singleSelectOption?.name);
-  if (direct) return direct;
-  const optionId = scalarId(value, 'option');
+  const field = fieldValue(item, statusField.id);
+  const selected = field?.value ?? field?.option ?? field?.single_select_option ?? field?.singleSelectOption;
+  const direct = rawText(selected?.name ?? selected?.title ?? selected?.text ?? selected);
+  if (direct && direct !== statusField.name) return direct;
+  const optionId = scalarId(field, 'option');
   const option = (statusField.options ?? []).find((entry) => String(entry.id) === String(optionId));
   return option ? rawText(option.name) : null;
 }

--- a/.github/scripts/project-iteration.mjs
+++ b/.github/scripts/project-iteration.mjs
@@ -12,6 +12,7 @@ export const STATUS_CATEGORIES = Object.freeze({
   Ready: 'unstarted',
   'In Progress': 'started',
   'In Review': 'started',
+  Blocked: 'started',
   Done: 'completed',
   Canceled: 'canceled',
   Cancelled: 'canceled',

--- a/.github/scripts/project-iteration.mjs
+++ b/.github/scripts/project-iteration.mjs
@@ -4,6 +4,7 @@ const DEFAULT_ORG = 'sfbrigade';
 const DEFAULT_PROJECT_NUMBER = 13;
 const DEFAULT_TIME_ZONE = 'America/Los_Angeles';
 const API_VERSION = '2026-03-10';
+const SPECIAL_TRIAGE_LABEL = 'needs triage';
 
 export const STATUS_CATEGORIES = Object.freeze({
   Backlog: 'backlog',
@@ -18,32 +19,6 @@ export const STATUS_CATEGORIES = Object.freeze({
 
 const ROLLOVER_CATEGORIES = new Set(['unstarted', 'started']);
 const AUTO_ASSIGN_CATEGORIES = new Set(['started']);
-const SPECIAL_TRIAGE_LABEL = 'needs triage';
-
-function rawText(value) {
-  if (value == null) return null;
-  if (typeof value === 'string') return value;
-  if (typeof value !== 'object') return String(value);
-  for (const candidate of [value.raw, value.name, value.title, value.text, value.html]) {
-    const text = rawText(candidate);
-    if (text != null) return text;
-  }
-  return null;
-}
-
-function scalarId(value, kind) {
-  if (value == null) return null;
-  if (typeof value === 'string' || typeof value === 'number') return String(value);
-  if (typeof value !== 'object') return null;
-  const candidates = kind === 'iteration'
-    ? [value.iteration_id, value.iterationId, value.iteration?.id, value.id, value.value]
-    : [value.option_id, value.optionId, value.option?.id, value.single_select_option?.id, value.singleSelectOption?.id, value.id, value.value];
-  for (const candidate of candidates) {
-    const id = scalarId(candidate, kind);
-    if (id != null) return id;
-  }
-  return null;
-}
 
 export function addDays(date, days) {
   const d = new Date(`${date}T00:00:00Z`);
@@ -64,20 +39,14 @@ export function localDate(timeZone = DEFAULT_TIME_ZONE, now = new Date()) {
 }
 
 export function classifyStatus(status, labels = []) {
-  const normalizedLabels = new Set(labels.map((label) => label.toLowerCase()));
-  if (normalizedLabels.has(SPECIAL_TRIAGE_LABEL)) return 'triage';
+  const normalized = new Set(labels.map((label) => String(label).toLowerCase()));
+  if (normalized.has(SPECIAL_TRIAGE_LABEL)) return 'triage';
   const category = STATUS_CATEGORIES[status];
   if (!category) throw new Error(`Unknown Status option: ${JSON.stringify(status)}`);
   return category;
 }
 
-export function decideTransition({
-  issueState,
-  status,
-  labels = [],
-  iterationRelation,
-  sourceMatches = true,
-}) {
+export function decideTransition({ issueState, status, labels = [], iterationRelation }) {
   if (issueState === 'closed') return { action: 'keep', reason: 'underlying-issue-closed' };
 
   const category = classifyStatus(status, labels);
@@ -85,18 +54,15 @@ export function decideTransition({
   if (category === 'completed') return { action: 'keep', reason: 'completed-history' };
   if (category === 'canceled') return { action: 'keep', reason: 'canceled' };
   if (category === 'backlog') return { action: 'keep', reason: 'backlog-does-not-roll' };
-
-  if (iterationRelation === 'future') return { action: 'keep', reason: 'future-scheduling-preserved' };
   if (iterationRelation === 'current') return { action: 'keep', reason: 'already-current' };
+  if (iterationRelation === 'future') return { action: 'keep', reason: 'future-scheduling-preserved' };
 
-  if (iterationRelation === 'past' && sourceMatches && ROLLOVER_CATEGORIES.has(category)) {
+  if (iterationRelation === 'past' && ROLLOVER_CATEGORIES.has(category)) {
     return { action: 'move-current', reason: 'expired-committed-work' };
   }
-
   if (iterationRelation === 'blank' && AUTO_ASSIGN_CATEGORIES.has(category)) {
     return { action: 'move-current', reason: 'started-work-must-be-current' };
   }
-
   return { action: 'keep', reason: 'no-rule' };
 }
 
@@ -106,19 +72,15 @@ function parseArgs(argv) {
     projectNumber: Number(process.env.PROJECT_NUMBER || DEFAULT_PROJECT_NUMBER),
     timeZone: process.env.PROJECT_TIME_ZONE || DEFAULT_TIME_ZONE,
     sourceIteration: process.env.SOURCE_ITERATION || null,
-    debug: false,
   };
-
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--org') args.org = argv[++i];
     else if (arg === '--project-number') args.projectNumber = Number(argv[++i]);
     else if (arg === '--time-zone') args.timeZone = argv[++i];
     else if (arg === '--from-iteration') args.sourceIteration = argv[++i];
-    else if (arg === '--debug') args.debug = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
-
   if (!args.org) throw new Error('Organization is required');
   if (!Number.isInteger(args.projectNumber) || args.projectNumber < 1) {
     throw new Error(`Invalid project number: ${args.projectNumber}`);
@@ -126,7 +88,7 @@ function parseArgs(argv) {
   return args;
 }
 
-function apiHeaders() {
+function headers() {
   return {
     Accept: 'application/vnd.github+json',
     'X-GitHub-Api-Version': API_VERSION,
@@ -134,21 +96,16 @@ function apiHeaders() {
   };
 }
 
-async function githubGet(url) {
-  const response = await fetch(url, { headers: apiHeaders() });
+async function githubGetJson(url) {
+  const response = await fetch(url, { headers: headers() });
   if (!response.ok) {
     const body = await response.text();
     throw new Error(`GitHub GET ${url} failed: ${response.status} ${body.slice(0, 1000)}`);
   }
-  return response;
-}
-
-async function githubGetJson(url) {
-  const response = await githubGet(url);
   return { data: await response.json(), response };
 }
 
-function parseNextLink(link) {
+function nextLink(link) {
   if (!link) return null;
   for (const part of link.split(',')) {
     const match = part.match(/<([^>]+)>;\s*rel="([^"]+)"/);
@@ -158,27 +115,47 @@ function parseNextLink(link) {
 }
 
 async function getAllPages(initialUrl) {
-  const all = [];
+  const rows = [];
   let url = initialUrl;
   while (url) {
     const { data, response } = await githubGetJson(url);
-    if (!Array.isArray(data)) {
-      throw new Error(`Expected array from ${url}; got ${JSON.stringify(data).slice(0, 1500)}`);
-    }
-    all.push(...data);
-    url = parseNextLink(response.headers.get('link'));
+    if (!Array.isArray(data)) throw new Error(`Expected array from ${url}`);
+    rows.push(...data);
+    url = nextLink(response.headers.get('link'));
   }
-  return all;
+  return rows;
+}
+
+function rawText(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value !== 'object') return String(value);
+  for (const candidate of [value.raw, value.name, value.title, value.text, value.html]) {
+    const result = rawText(candidate);
+    if (result != null) return result;
+  }
+  return null;
+}
+
+function scalarId(value, kind) {
+  if (value == null) return null;
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  if (typeof value !== 'object') return null;
+  const candidates = kind === 'iteration'
+    ? [value.iteration_id, value.iterationId, value.iteration?.id, value.id, value.value]
+    : [value.option_id, value.optionId, value.option?.id, value.single_select_option?.id,
+      value.singleSelectOption?.id, value.id, value.value];
+  for (const candidate of candidates) {
+    const id = scalarId(candidate, kind);
+    if (id != null) return id;
+  }
+  return null;
 }
 
 function findField(fields, name, dataType) {
-  const matches = fields.filter(
-    (field) => field.name === name && (!dataType || field.data_type === dataType),
-  );
+  const matches = fields.filter((field) => field.name === name && (!dataType || field.data_type === dataType));
   if (matches.length !== 1) {
-    throw new Error(
-      `Expected exactly one ${name} field${dataType ? ` (${dataType})` : ''}; found ${matches.length}`,
-    );
+    throw new Error(`Expected exactly one ${name} field (${dataType}); found ${matches.length}`);
   }
   return matches[0];
 }
@@ -189,24 +166,12 @@ function normalizeIterations(iterationField) {
   if (configuration.duration !== 14) {
     throw new Error(`Expected 14-day Iterations; field duration is ${configuration.duration}`);
   }
-
-  const candidates = [
-    ...(configuration.completed_iterations ?? []),
-    ...(configuration.completedIterations ?? []),
-    ...(configuration.iterations ?? []),
-  ];
-  const byId = new Map();
-  for (const iteration of candidates) {
-    const normalized = {
-      id: String(iteration.id),
-      title: rawText(iteration.title) ?? String(iteration.id),
-      startDate: iteration.start_date ?? iteration.startDate,
-      duration: iteration.duration ?? configuration.duration,
-    };
-    if (!normalized.id || !normalized.startDate || !normalized.title) continue;
-    byId.set(normalized.id, normalized);
-  }
-  return [...byId.values()].sort((a, b) => a.startDate.localeCompare(b.startDate));
+  return (configuration.iterations ?? []).map((iteration) => ({
+    id: String(iteration.id),
+    title: rawText(iteration.title) ?? String(iteration.id),
+    startDate: iteration.start_date ?? iteration.startDate,
+    duration: iteration.duration ?? configuration.duration,
+  })).filter((iteration) => iteration.id && iteration.startDate);
 }
 
 export function resolveIterationState(iterations, today) {
@@ -214,86 +179,46 @@ export function resolveIterationState(iterations, today) {
     (iteration) => iteration.startDate <= today && today < addDays(iteration.startDate, iteration.duration),
   );
   if (!current) throw new Error(`No current Iteration contains ${today}; refusing to guess`);
-
   const future = iterations.filter((iteration) => iteration.startDate > current.startDate);
   return { current, future };
 }
 
-function matchesIterationSelector(iteration, selector) {
-  if (!selector) return true;
-  if (!iteration) return false;
-  const wanted = String(selector).trim().toLowerCase();
-  const title = String(iteration.title).toLowerCase();
-  if (title === wanted) return true;
-  if (title === `iteration ${wanted}`) return true;
-  if (String(iteration.id).toLowerCase() === wanted) return true;
-  return false;
-}
-
-function lookupFieldContainer(item, fieldId) {
-  const containers = [item.field_values, item.fieldValues, item.fields];
-  for (const container of containers) {
+function fieldValue(item, fieldId) {
+  for (const container of [item.field_values, item.fieldValues, item.fields]) {
     if (!container) continue;
     if (Array.isArray(container)) {
-      const match = container.find((value) => {
-        const candidate = value.field_id ?? value.fieldId ?? value.field?.id ?? value.id;
-        return String(candidate) === String(fieldId);
-      });
-      if (match) return match;
+      const found = container.find((value) => String(value.field_id ?? value.fieldId ?? value.field?.id ?? value.id) === String(fieldId));
+      if (found) return found;
     } else if (typeof container === 'object') {
       const direct = container[fieldId] ?? container[String(fieldId)];
       if (direct !== undefined) return direct;
-      const match = Object.values(container).find((value) => {
-        if (!value || typeof value !== 'object') return false;
-        const candidate = value.field_id ?? value.fieldId ?? value.field?.id;
-        return String(candidate) === String(fieldId);
-      });
-      if (match) return match;
+      const found = Object.values(container).find((value) =>
+        value && typeof value === 'object'
+        && String(value.field_id ?? value.fieldId ?? value.field?.id) === String(fieldId));
+      if (found) return found;
     }
   }
   return null;
 }
 
-function iterationIdFromValue(value) {
-  return scalarId(value, 'iteration');
-}
-
-function optionIdFromValue(value) {
-  return scalarId(value, 'option');
-}
-
-function statusNameForItem(item, statusField) {
-  const value = lookupFieldContainer(item, statusField.id);
-  const directName = rawText(value?.name ?? value?.option?.name ?? value?.single_select_option?.name ?? value?.singleSelectOption?.name);
-  if (directName) return directName;
-  const optionId = optionIdFromValue(value);
-  if (!optionId) return null;
+function statusName(item, statusField) {
+  const value = fieldValue(item, statusField.id);
+  const direct = rawText(value?.name ?? value?.option?.name ?? value?.single_select_option?.name ?? value?.singleSelectOption?.name);
+  if (direct) return direct;
+  const optionId = scalarId(value, 'option');
   const option = (statusField.options ?? []).find((entry) => String(entry.id) === String(optionId));
   return option ? rawText(option.name) : null;
 }
 
-function iterationForItem(item, iterationField, iterationById) {
-  const value = lookupFieldContainer(item, iterationField.id);
-  const iterationId = iterationIdFromValue(value);
-  if (!iterationId) return null;
-  const configured = iterationById.get(String(iterationId));
-  if (configured) return configured;
-  return {
-    id: String(iterationId),
-    title: rawText(value?.title ?? value?.iteration?.title) ?? String(iterationId),
-    startDate: value?.start_date ?? value?.startDate ?? value?.iteration?.start_date ?? value?.iteration?.startDate,
-    duration: value?.duration ?? value?.iteration?.duration ?? 14,
-  };
+function contentType(item) {
+  return item.content_type ?? item.contentType ?? item.type ?? null;
 }
 
-function itemIssueApiUrl(item) {
+function issueApiUrl(item) {
   const content = item.content ?? {};
-  if (typeof content.url === 'string' && /\/repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(content.url)) {
-    return content.url;
-  }
+  if (typeof content.url === 'string' && /\/repos\/[^/]+\/[^/]+\/issues\/\d+$/.test(content.url)) return content.url;
   const repositoryUrl = content.repository_url ?? content.repositoryUrl;
-  const number = content.number;
-  if (repositoryUrl && number) return `${repositoryUrl}/issues/${number}`;
+  if (repositoryUrl && content.number) return `${repositoryUrl}/issues/${content.number}`;
   if (typeof content.html_url === 'string') {
     const match = content.html_url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)$/);
     if (match) return `https://api.github.com/repos/${match[1]}/${match[2]}/issues/${match[3]}`;
@@ -303,10 +228,7 @@ function itemIssueApiUrl(item) {
 
 function normalizeLabels(labels) {
   if (!Array.isArray(labels)) return [];
-  return labels
-    .map((label) => (typeof label === 'string' ? label : label?.name))
-    .filter(Boolean)
-    .map((label) => label.toLowerCase());
+  return labels.map((label) => typeof label === 'string' ? label : label?.name).filter(Boolean).map((label) => label.toLowerCase());
 }
 
 async function issueMetadata(item) {
@@ -314,56 +236,75 @@ async function issueMetadata(item) {
   if (content.state && Array.isArray(content.labels)) {
     return { state: content.state, labels: normalizeLabels(content.labels), number: content.number, title: content.title };
   }
-  const url = itemIssueApiUrl(item);
-  if (!url) {
-    return { state: content.state ?? 'unknown', labels: [], number: content.number, title: content.title };
-  }
+  const url = issueApiUrl(item);
+  if (!url) return { state: content.state ?? 'unknown', labels: [], number: content.number, title: content.title };
   const { data } = await githubGetJson(url);
   return { state: data.state, labels: normalizeLabels(data.labels), number: data.number, title: data.title };
 }
 
-function contentType(item) {
-  return item.content_type ?? item.contentType ?? item.type ?? null;
+function sourceTitle(selector) {
+  if (!selector) return null;
+  const text = String(selector).trim();
+  return /^\d+$/.test(text) ? `Iteration ${text}` : text;
 }
 
-function relationFor(iteration, current, today) {
-  if (!iteration) return 'blank';
-  if (iteration.id === current.id) return 'current';
-  if (iteration.startDate && iteration.startDate > today) return 'future';
-  if (iteration.startDate && addDays(iteration.startDate, iteration.duration ?? 14) <= today) return 'past';
-  return 'unknown';
+function itemQueryUrl(base, fieldIds, query) {
+  const params = new URLSearchParams({ fields: fieldIds, per_page: '100', q: query });
+  return `${base}/items?${params.toString()}`;
 }
 
-function titleForItem(item, metadata) {
-  return metadata.title ?? item.content?.title ?? item.title ?? '(untitled)';
-}
-
-function printResult({ current, future, sourceIteration, moves, keeps, warnings }) {
+function printResult({ current, future, source, moves, keeps, warnings }) {
   console.log(`CURRENT: ${current.title} (${current.startDate} → ${addDays(current.startDate, current.duration)})`);
   console.log(`FUTURE ITERATIONS: ${future.length}`);
-  if (sourceIteration) console.log(`SOURCE FILTER: ${sourceIteration}`);
+  if (source) console.log(`SOURCE: ${source}`);
   console.log('');
-
   if (warnings.length) {
     console.log('WARNINGS');
-    for (const warning of warnings) console.log(`- ${warning}`);
+    warnings.forEach((warning) => console.log(`- ${warning}`));
     console.log('');
   }
-
   console.log('WOULD MOVE');
   if (!moves.length) console.log('(none)');
-  for (const row of moves) {
-    console.log(`#${row.number ?? '?'}  ${row.status}  ${row.from} → ${current.title}  [${row.reason}]  ${row.title}`);
-  }
+  moves.forEach((row) => console.log(`#${row.number ?? '?'}  ${row.status}  ${row.from} → ${current.title}  [${row.reason}]  ${row.title}`));
   console.log('');
-
   console.log('WOULD KEEP');
   if (!keeps.length) console.log('(none)');
-  for (const row of keeps) {
-    console.log(`#${row.number ?? '?'}  ${row.status ?? '(no status)'}  ${row.from}  [${row.reason}]  ${row.title}`);
-  }
+  keeps.forEach((row) => console.log(`#${row.number ?? '?'}  ${row.status ?? '(no status)'}  ${row.from}  [${row.reason}]  ${row.title}`));
   console.log('');
   console.log(`SUMMARY move=${moves.length} keep=${keeps.length} warnings=${warnings.length}`);
+}
+
+async function classifyItems(items, { statusField, relation, from }) {
+  const moves = [];
+  const keeps = [];
+  for (const item of items) {
+    const type = contentType(item);
+    if (type && String(type).toLowerCase() !== 'issue') continue;
+
+    const status = statusName(item, statusField);
+    const metadata = await issueMetadata(item);
+    if (!status) {
+      keeps.push({ number: metadata.number, title: metadata.title ?? '(untitled)', status: null, from, reason: 'missing-status' });
+      continue;
+    }
+
+    const decision = decideTransition({
+      issueState: metadata.state,
+      status,
+      labels: metadata.labels,
+      iterationRelation: relation,
+    });
+    const row = {
+      itemId: item.id,
+      number: metadata.number,
+      title: metadata.title ?? item.content?.title ?? '(untitled)',
+      status,
+      from,
+      reason: decision.reason,
+    };
+    (decision.action === 'move-current' ? moves : keeps).push(row);
+  }
+  return { moves, keeps };
 }
 
 export async function main(argv = process.argv.slice(2)) {
@@ -373,81 +314,33 @@ export async function main(argv = process.argv.slice(2)) {
 
   const { data: fields } = await githubGetJson(`${base}/fields?per_page=100`);
   if (!Array.isArray(fields)) throw new Error('Project fields response was not an array');
-
   const statusField = findField(fields, 'Status', 'single_select');
   const iterationField = findField(fields, 'Iteration', 'iteration');
   const iterations = normalizeIterations(iterationField);
-  const iterationById = new Map(iterations.map((iteration) => [iteration.id, iteration]));
   const { current, future } = resolveIterationState(iterations, today);
 
   const warnings = [];
-  if (future.length < 3) {
-    warnings.push(`Only ${future.length} future Iteration(s) configured; manually keep at least 3 available.`);
-  }
+  if (future.length < 3) warnings.push(`Only ${future.length} future Iteration(s) configured; manually keep at least 3 available.`);
 
   const fieldIds = `${statusField.id},${iterationField.id}`;
-  const items = await getAllPages(`${base}/items?fields=${encodeURIComponent(fieldIds)}&per_page=100`);
+  let moves = [];
+  let keeps = [];
+  let source = null;
 
-  const moves = [];
-  const keeps = [];
-  let recognizedFieldShape = false;
-
-  for (const item of items) {
-    const type = contentType(item);
-    if (type && String(type).toLowerCase() !== 'issue') continue;
-
-    const status = statusNameForItem(item, statusField);
-    const iteration = iterationForItem(item, iterationField, iterationById);
-    if (lookupFieldContainer(item, statusField.id) || lookupFieldContainer(item, iterationField.id)) {
-      recognizedFieldShape = true;
-    }
-
-    if (args.sourceIteration && !matchesIterationSelector(iteration, args.sourceIteration)) continue;
-    if (!args.sourceIteration && !iteration && status && classifyStatus(status, []) !== 'started') continue;
-
-    const metadata = await issueMetadata(item);
-    const relation = relationFor(iteration, current, today);
-    if (relation === 'unknown') {
-      throw new Error(`Cannot classify Iteration relation for item ${item.id ?? item.node_id}`);
-    }
-
-    if (!status) {
-      keeps.push({
-        number: metadata.number,
-        title: titleForItem(item, metadata),
-        status: null,
-        from: iteration?.title ?? 'none',
-        reason: 'missing-status',
-      });
-      continue;
-    }
-
-    const decision = decideTransition({
-      issueState: metadata.state,
-      status,
-      labels: metadata.labels,
-      iterationRelation: relation,
-      sourceMatches: true,
-    });
-
-    const row = {
-      itemId: item.id,
-      number: metadata.number,
-      title: titleForItem(item, metadata),
-      status,
-      from: iteration?.title ?? 'none',
-      reason: decision.reason,
-    };
-    if (decision.action === 'move-current') moves.push(row);
-    else keeps.push(row);
+  if (args.sourceIteration) {
+    source = sourceTitle(args.sourceIteration);
+    const items = await getAllPages(itemQueryUrl(base, fieldIds, `iteration:"${source}"`));
+    ({ moves, keeps } = await classifyItems(items, { statusField, relation: 'past', from: source }));
+  } else {
+    const pastItems = await getAllPages(itemQueryUrl(base, fieldIds, 'iteration:<@current'));
+    const blankItems = await getAllPages(itemQueryUrl(base, fieldIds, 'no:iteration'));
+    const past = await classifyItems(pastItems, { statusField, relation: 'past', from: 'past Iteration' });
+    const blank = await classifyItems(blankItems, { statusField, relation: 'blank', from: 'none' });
+    moves = [...past.moves, ...blank.moves];
+    keeps = [...past.keeps, ...blank.keeps];
   }
 
-  if (!recognizedFieldShape && items.length) {
-    const sample = JSON.stringify(items[0], null, 2).slice(0, 8000);
-    throw new Error(`Unrecognized Project item field-value shape. Bounded sample:\n${sample}`);
-  }
-
-  printResult({ current, future, sourceIteration: args.sourceIteration, moves, keeps, warnings });
+  printResult({ current, future, source, moves, keeps, warnings });
 }
 
 const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;

--- a/.github/scripts/project-iteration.test.mjs
+++ b/.github/scripts/project-iteration.test.mjs
@@ -12,6 +12,7 @@ test('classifies SafeHome statuses into Linear-like categories', () => {
   assert.equal(classifyStatus('Todo'), 'unstarted');
   assert.equal(classifyStatus('In Progress'), 'started');
   assert.equal(classifyStatus('In Review'), 'started');
+  assert.equal(classifyStatus('Blocked'), 'started');
   assert.equal(classifyStatus('Done'), 'completed');
   assert.equal(classifyStatus('Canceled'), 'canceled');
 });
@@ -25,7 +26,7 @@ test('unknown statuses fail closed', () => {
 });
 
 test('rolls committed unstarted and started work from a past iteration', () => {
-  for (const status of ['Todo', 'In Progress', 'In Review']) {
+  for (const status of ['Todo', 'In Progress', 'In Review', 'Blocked']) {
     assert.deepEqual(
       decideTransition({ issueState: 'open', status, iterationRelation: 'past' }),
       { action: 'move-current', reason: 'expired-committed-work' },
@@ -44,6 +45,7 @@ test('does not roll backlog, triage, completed, canceled, or closed issues', () 
 test('assigns only started blank work to current', () => {
   assert.equal(decideTransition({ issueState: 'open', status: 'In Progress', iterationRelation: 'blank' }).action, 'move-current');
   assert.equal(decideTransition({ issueState: 'open', status: 'In Review', iterationRelation: 'blank' }).action, 'move-current');
+  assert.equal(decideTransition({ issueState: 'open', status: 'Blocked', iterationRelation: 'blank' }).action, 'move-current');
   assert.equal(decideTransition({ issueState: 'open', status: 'Todo', iterationRelation: 'blank' }).action, 'keep');
 });
 

--- a/.github/scripts/project-iteration.test.mjs
+++ b/.github/scripts/project-iteration.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  addDays,
+  classifyStatus,
+  decideTransition,
+  resolveIterationState,
+} from './project-iteration.mjs';
+
+test('classifies SafeHome statuses into Linear-like categories', () => {
+  assert.equal(classifyStatus('Backlog'), 'backlog');
+  assert.equal(classifyStatus('Todo'), 'unstarted');
+  assert.equal(classifyStatus('In Progress'), 'started');
+  assert.equal(classifyStatus('In Review'), 'started');
+  assert.equal(classifyStatus('Done'), 'completed');
+  assert.equal(classifyStatus('Canceled'), 'canceled');
+});
+
+test('needs triage overrides the ordinary status category', () => {
+  assert.equal(classifyStatus('Todo', ['needs triage']), 'triage');
+});
+
+test('unknown statuses fail closed', () => {
+  assert.throws(() => classifyStatus('Mystery'), /Unknown Status option/);
+});
+
+test('rolls committed unstarted and started work from a past iteration', () => {
+  for (const status of ['Todo', 'In Progress', 'In Review']) {
+    assert.deepEqual(
+      decideTransition({ issueState: 'open', status, iterationRelation: 'past' }),
+      { action: 'move-current', reason: 'expired-committed-work' },
+    );
+  }
+});
+
+test('does not roll backlog, triage, completed, canceled, or closed issues', () => {
+  assert.equal(decideTransition({ issueState: 'open', status: 'Backlog', iterationRelation: 'past' }).action, 'keep');
+  assert.equal(decideTransition({ issueState: 'open', status: 'Todo', labels: ['needs triage'], iterationRelation: 'past' }).action, 'keep');
+  assert.equal(decideTransition({ issueState: 'open', status: 'Done', iterationRelation: 'past' }).action, 'keep');
+  assert.equal(decideTransition({ issueState: 'open', status: 'Canceled', iterationRelation: 'past' }).action, 'keep');
+  assert.equal(decideTransition({ issueState: 'closed', status: 'In Progress', iterationRelation: 'past' }).action, 'keep');
+});
+
+test('assigns only started blank work to current', () => {
+  assert.equal(decideTransition({ issueState: 'open', status: 'In Progress', iterationRelation: 'blank' }).action, 'move-current');
+  assert.equal(decideTransition({ issueState: 'open', status: 'In Review', iterationRelation: 'blank' }).action, 'move-current');
+  assert.equal(decideTransition({ issueState: 'open', status: 'Todo', iterationRelation: 'blank' }).action, 'keep');
+});
+
+test('preserves current and future manual scheduling', () => {
+  assert.equal(decideTransition({ issueState: 'open', status: 'In Progress', iterationRelation: 'current' }).action, 'keep');
+  assert.equal(decideTransition({ issueState: 'open', status: 'Todo', iterationRelation: 'future' }).action, 'keep');
+});
+
+test('resolves current iteration from dates and fails if none exists', () => {
+  const iterations = [
+    { id: 'a', title: 'Iteration 33', startDate: '2026-08-06', duration: 14 },
+    { id: 'b', title: 'Iteration 34', startDate: '2026-08-20', duration: 14 },
+    { id: 'c', title: 'Iteration 35', startDate: '2026-09-03', duration: 14 },
+  ];
+  assert.equal(resolveIterationState(iterations, '2026-09-02').current.id, 'b');
+  assert.equal(resolveIterationState(iterations, '2026-09-02').future.length, 1);
+  assert.throws(() => resolveIterationState(iterations, '2026-10-01'), /No current Iteration/);
+});
+
+test('date math uses half-open iteration boundaries', () => {
+  assert.equal(addDays('2026-08-20', 14), '2026-09-03');
+});

--- a/.github/workflows/project-iteration.yml
+++ b/.github/workflows/project-iteration.yml
@@ -1,0 +1,38 @@
+name: Project iteration dry run
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_iteration:
+        description: 'Optional source Iteration title/number to inspect (for example: 33)'
+        required: false
+        default: '33'
+  pull_request:
+    paths:
+      - '.github/workflows/project-iteration.yml'
+      - '.github/scripts/project-iteration.mjs'
+      - '.github/scripts/project-iteration.test.mjs'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: safehome-project-iteration
+  cancel-in-progress: false
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run policy tests
+        run: node --test .github/scripts/project-iteration.test.mjs
+
+      - name: Inspect Project rollover candidates
+        env:
+          PROJECT_ORG: sfbrigade
+          PROJECT_NUMBER: '13'
+          PROJECT_TIME_ZONE: America/Los_Angeles
+          SOURCE_ITERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.from_iteration || '33' }}
+        run: node .github/scripts/project-iteration.mjs --from-iteration "$SOURCE_ITERATION"

--- a/.github/workflows/project-iteration.yml
+++ b/.github/workflows/project-iteration.yml
@@ -34,5 +34,11 @@ jobs:
           PROJECT_ORG: sfbrigade
           PROJECT_NUMBER: '13'
           PROJECT_TIME_ZONE: America/Los_Angeles
-          SOURCE_ITERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.from_iteration || '33' }}
-        run: node .github/scripts/project-iteration.mjs --from-iteration "$SOURCE_ITERATION"
+          SOURCE_ITERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.from_iteration || '' }}
+        shell: bash
+        run: |
+          if [[ -n "$SOURCE_ITERATION" ]]; then
+            node .github/scripts/project-iteration.mjs --from-iteration "$SOURCE_ITERATION"
+          else
+            node .github/scripts/project-iteration.mjs
+          fi

--- a/.github/workflows/project-iteration.yml
+++ b/.github/workflows/project-iteration.yml
@@ -29,6 +29,29 @@ jobs:
       - name: Run policy tests
         run: node --test .github/scripts/project-iteration.test.mjs
 
+      - name: Probe source Iteration with Project search
+        env:
+          SOURCE_ITERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.from_iteration || '33' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          selector="$SOURCE_ITERATION"
+          if [[ "$selector" =~ ^[0-9]+$ ]]; then
+            selector="Iteration $selector"
+          fi
+
+          response="$(curl --fail-with-body --silent --show-error --get \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2026-03-10' \
+            --data-urlencode "q=iteration:\"$selector\"" \
+            --data-urlencode 'per_page=100' \
+            'https://api.github.com/orgs/sfbrigade/projectsV2/13/items')"
+
+          count="$(jq 'length' <<<"$response")"
+          echo "REST_PROJECT_QUERY=iteration:\"$selector\""
+          echo "REST_PROJECT_MATCHES=$count"
+          jq -r '.[] | "#\(.content.number // "?")  \(.content.title // "(untitled)")"' <<<"$response"
+
       - name: Inspect Project rollover candidates
         env:
           PROJECT_ORG: sfbrigade

--- a/.github/workflows/project-iteration.yml
+++ b/.github/workflows/project-iteration.yml
@@ -57,11 +57,6 @@ jobs:
           PROJECT_ORG: sfbrigade
           PROJECT_NUMBER: '13'
           PROJECT_TIME_ZONE: America/Los_Angeles
-          SOURCE_ITERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.from_iteration || '' }}
+          SOURCE_ITERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.from_iteration || '33' }}
         shell: bash
-        run: |
-          if [[ -n "$SOURCE_ITERATION" ]]; then
-            node .github/scripts/project-iteration.mjs --from-iteration "$SOURCE_ITERATION"
-          else
-            node .github/scripts/project-iteration.mjs
-          fi
+        run: node .github/scripts/project-iteration.mjs --from-iteration "$SOURCE_ITERATION"


### PR DESCRIPTION
## Summary

Adds a read-only SafeHome Project iteration controller and policy tests.

The controller currently performs no Project writes. It inspects Project #13, determines the current 14-day Iteration from configured dates, and reports which issues would move under the Linear-like policy:

- expired + Unstarted/Started -> current
- Started + no Iteration -> current
- Triage/Backlog/Completed/Canceled/closed issues -> unchanged
- current/future manual scheduling -> unchanged
- unknown Status or missing current Iteration -> fail closed
- fewer than 3 future Iterations -> warning

The workflow defaults to a dry run from Iteration 33 and can also be manually dispatched with another source Iteration.

## Testing

- `node --test .github/scripts/project-iteration.test.mjs`
- Local policy suite: 9/9 passing
- PR workflow will exercise the read-only REST integration against live Project #13

## Safety

- read-only `contents: read` workflow permissions
- no Project mutation endpoint
- no Project write token/secrets
- concurrency guard included for the later mutation phase


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only GitHub Project iteration dry run for reviewing rollover candidates and transition decisions.
  * Added support for normalized iteration selectors, status classification including blocked work, pagination, warnings, and metadata fallback.
  * Added manually or pull-request-triggered workflow checks with a default iteration selector.

* **Tests**
  * Added coverage for status classification, iteration transitions, current-iteration resolution, missing-current errors, and date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->