### PR TITLE
Use asterisk separators in Feature form

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-feature.yml
+++ b/.github/ISSUE_TEMPLATE/01-feature.yml
@@ -11,7 +11,7 @@ body:
       value: |
         What problem should this Feature address? Describe the situation, what someone is trying to do, and what gets in the way.
 
-        ---
+        ***
     validations:
       required: true
 
@@ -32,7 +32,7 @@ body:
         - [ ] Criterion 1
         - [ ] Criterion 2
 
-        ---
+        ***
     validations:
       required: false
 
@@ -48,7 +48,7 @@ body:
         **Additional context**
         What else is worth knowing about this Feature?
 
-        ---
+        ***
     validations:
       required: false
 


### PR DESCRIPTION
## Summary

Replace the three Feature form horizontal-rule markers from `---` to `***`.

No other Issue Form or workflow changes.

## Verification

- based directly on current `develop` at `bdfe95558c8e9824088f0dbb94a3c4d42ea89ac2`
- only `.github/ISSUE_TEMPLATE/01-feature.yml` changes
- branch content re-fetched after the update
