### PR TITLE
Align Task and Bug issue forms with Feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-task.yml
+++ b/.github/ISSUE_TEMPLATE/02-task.yml
@@ -8,11 +8,10 @@ body:
     id: task
     attributes:
       label: Task
-      description: >-
-        Describe the work to do and why it matters.
-      placeholder: |
-        Create the design spec for the hazard-term explanation, including its
-        placement, interaction states, and responsive behavior.
+      value: |
+        What needs to be done, and why does it matter?
+
+        ***
     validations:
       required: true
 
@@ -20,12 +19,13 @@ body:
     id: completion-criteria
     attributes:
       label: Completion criteria
-      description: >-
-        What must be true for this task to be complete?
       value: |
-        - [ ]
-        - [ ]
-        - [ ]
+        What must be true for this Task to be complete?
+
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+
+        ***
     validations:
       required: false
 
@@ -33,14 +33,10 @@ body:
     id: context
     attributes:
       label: Context
-      description: >-
-        References, constraints, decisions, and other useful context.
       value: |
-        **Reference(s):**
-        <!-- e.g. a URL, spec, design artifact, issue, PR, or other relevant
-        source. -->
+        **Reference(s):** https://..
 
         **Additional context**
-        <!-- Add anything else worth knowing about this task. -->
+        What else is worth knowing about this Task?
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/03-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03-bug.yml
@@ -8,34 +8,33 @@ body:
     id: bug-report
     attributes:
       label: Bug report
-      description: >-
-        Describe the problem with enough detail to understand and investigate it.
       value: |
         **Observed behavior**
-        <!-- What happened? -->
+        What happened?
 
         **Expected behavior**
-        <!-- What should have happened instead? -->
+        What should have happened instead?
 
         **Steps to reproduce**
-        <!-- Add steps if known. -->
-        1. <!-- First step -->
-        2. <!-- Next step -->
-        3. <!-- What shows the problem? -->
+        What steps reproduce the problem, if known?
+
+        1. Step 1
+        2. Step 2
+        3. Step 3
+
+        ***
     validations:
-      required: false
+      required: true
 
   - type: textarea
     id: context
     attributes:
       label: Context
-      description: >-
-        Environment details, screenshots, logs, links, and anything else useful.
       value: |
-        **Environment:**
-        <!-- Device, OS, browser/version, or other relevant details. -->
+        **Environment**
+        What device, OS, browser/version, or other environment details are relevant?
 
         **Additional context**
-        <!-- Screenshots, logs, links, or anything else useful. -->
+        What else would help investigate this Bug? Add screenshots, logs, or links if useful.
     validations:
       required: false


### PR DESCRIPTION
## Summary

Align Task and Bug Issue Forms with the simpler durable authoring pattern established by the Feature form.

- move important guidance into durable visible `value` content
- remove textarea `description` / `placeholder` guidance and hidden HTML comments
- use `***` separators between generated Issue sections
- use two named completion-criteria placeholders for Task
- keep Task Context compact with a Reference(s) hint and Additional context
- keep Bug-specific observed/expected/reproduction structure while making prompts visible
- make the Bug report primary field required, matching Feature Problem and Task

No Feature form or Project workflow changes.

## Verification

- based directly on current `develop` after merged #1049 at `690989b6654a539cf37f030c9ba549e44c110151`
- branch is two commits ahead and zero behind `develop`
- diff changes only `.github/ISSUE_TEMPLATE/02-task.yml` and `.github/ISSUE_TEMPLATE/03-bug.yml`
- two commits: Task alignment, then Bug alignment
- re-fetched both resulting files after mutation
- root `AGENTS.md` re-read; it links no additional tracked process authority
