### PR TITLE
Clarify Feature work item guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-feature.yml
+++ b/.github/ISSUE_TEMPLATE/01-feature.yml
@@ -57,7 +57,10 @@ body:
     attributes:
       label: Work items
       value: |
-        Keep applicable items.
+        Shape this list to fit the Feature: add, edit, or remove items based on the work you currently expect. Keep it lightweight rather than trying to define the full work breakdown up front.
+
+        When a checklist item needs its own owner, status, discussion, or history, turn it into a sub-issue. If related work already exists as an issue, attach it as a sub-issue instead. Continue refining the list and hierarchy as the work becomes clearer.
+
         - [ ] Create Design spec
         - [ ] Conduct Data science analysis
         - [ ] Create Engineering spec


### PR DESCRIPTION
## Summary

Clarify how the Feature issue form's Work items section should be used.

- encourage authors/editors to add, edit, or remove anticipated work items
- keep the initial checklist lightweight rather than treating it as a complete work breakdown
- distinguish turning a checklist item into a sub-issue from attaching an existing issue as a sub-issue
- encourage the hierarchy to evolve as the work becomes clearer

## Scope

This PR changes only the guidance text above the existing Feature Work items checklist. It does not change labels, fields, checklist entries, or other issue-form behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the feature issue template’s work-item guidance to encourage lightweight, tailored checklists.
  - Clarified that work requiring separate ownership or history should be tracked in sub-issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->